### PR TITLE
feat: enhance URL normalization to handle all input formats

### DIFF
--- a/src/auth/__tests__/url-normalization.test.ts
+++ b/src/auth/__tests__/url-normalization.test.ts
@@ -1,0 +1,238 @@
+/**
+ * URL Normalization Unit Tests
+ *
+ * Tests for normalizeApiUrl(), normalizeTenantUrl(), and extractTenantFromUrl()
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  normalizeApiUrl,
+  normalizeTenantUrl,
+  extractTenantFromUrl,
+} from "../credential-manager.js";
+
+describe("normalizeApiUrl", () => {
+  describe("protocol handling", () => {
+    it("should add https:// when missing", () => {
+      expect(normalizeApiUrl("tenant.console.ves.volterra.io")).toBe(
+        "https://tenant.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should preserve existing https://", () => {
+      expect(normalizeApiUrl("https://tenant.console.ves.volterra.io")).toBe(
+        "https://tenant.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should preserve http:// for localhost", () => {
+      expect(normalizeApiUrl("http://localhost:8080")).toBe(
+        "http://localhost:8080/api"
+      );
+    });
+
+    it("should add https:// to staging URL without protocol", () => {
+      expect(normalizeApiUrl("nferreira.staging.volterra.us")).toBe(
+        "https://nferreira.staging.volterra.us/api"
+      );
+    });
+  });
+
+  describe("staging URLs", () => {
+    it("should handle staging.volterra.us with protocol", () => {
+      expect(normalizeApiUrl("https://nferreira.staging.volterra.us")).toBe(
+        "https://nferreira.staging.volterra.us/api"
+      );
+    });
+
+    it("should handle staging.volterra.us without protocol", () => {
+      expect(normalizeApiUrl("nferreira.staging.volterra.us")).toBe(
+        "https://nferreira.staging.volterra.us/api"
+      );
+    });
+
+    it("should handle staging with /api suffix", () => {
+      expect(normalizeApiUrl("nferreira.staging.volterra.us/api")).toBe(
+        "https://nferreira.staging.volterra.us/api"
+      );
+    });
+
+    it("should handle staging with https:// and /api suffix", () => {
+      expect(normalizeApiUrl("https://nferreira.staging.volterra.us/api")).toBe(
+        "https://nferreira.staging.volterra.us/api"
+      );
+    });
+  });
+
+  describe("console URLs", () => {
+    it("should handle console.ves.volterra.io without protocol", () => {
+      expect(normalizeApiUrl("f5-amer-ent.console.ves.volterra.io")).toBe(
+        "https://f5-amer-ent.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should handle console.ves.volterra.io with protocol", () => {
+      expect(normalizeApiUrl("https://f5-amer-ent.console.ves.volterra.io")).toBe(
+        "https://f5-amer-ent.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should handle console URL with /api suffix", () => {
+      expect(
+        normalizeApiUrl("https://f5-amer-ent.console.ves.volterra.io/api")
+      ).toBe("https://f5-amer-ent.console.ves.volterra.io/api");
+    });
+
+    it("should handle console URL without protocol but with /api suffix", () => {
+      expect(normalizeApiUrl("f5-amer-ent.console.ves.volterra.io/api")).toBe(
+        "https://f5-amer-ent.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should handle staging console URLs", () => {
+      expect(
+        normalizeApiUrl("tenant.staging.console.ves.volterra.io")
+      ).toBe("https://tenant.staging.console.ves.volterra.io/api");
+    });
+  });
+
+  describe("production short-form URLs", () => {
+    it("should convert tenant.volterra.us to console.ves with protocol", () => {
+      expect(normalizeApiUrl("https://tenant.volterra.us")).toBe(
+        "https://tenant.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should convert tenant.volterra.us to console.ves without protocol", () => {
+      expect(normalizeApiUrl("tenant.volterra.us")).toBe(
+        "https://tenant.console.ves.volterra.io/api"
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should trim leading whitespace", () => {
+      expect(normalizeApiUrl("  tenant.console.ves.volterra.io")).toBe(
+        "https://tenant.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should trim trailing whitespace", () => {
+      expect(normalizeApiUrl("tenant.console.ves.volterra.io  ")).toBe(
+        "https://tenant.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should trim both leading and trailing whitespace", () => {
+      expect(normalizeApiUrl("  tenant.console.ves.volterra.io  ")).toBe(
+        "https://tenant.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should handle empty string", () => {
+      expect(normalizeApiUrl("")).toBe("");
+    });
+
+    it("should handle whitespace-only string", () => {
+      expect(normalizeApiUrl("   ")).toBe("");
+    });
+
+    it("should handle trailing slashes", () => {
+      expect(normalizeApiUrl("https://tenant.console.ves.volterra.io/")).toBe(
+        "https://tenant.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should handle multiple trailing slashes", () => {
+      expect(normalizeApiUrl("https://tenant.console.ves.volterra.io///")).toBe(
+        "https://tenant.console.ves.volterra.io/api"
+      );
+    });
+
+    it("should handle /api/ with trailing slash", () => {
+      expect(
+        normalizeApiUrl("https://tenant.console.ves.volterra.io/api/")
+      ).toBe("https://tenant.console.ves.volterra.io/api");
+    });
+  });
+});
+
+describe("normalizeTenantUrl", () => {
+  it("should return URL without /api suffix for console URL", () => {
+    expect(normalizeTenantUrl("tenant.console.ves.volterra.io")).toBe(
+      "https://tenant.console.ves.volterra.io"
+    );
+  });
+
+  it("should return URL without /api suffix for staging URL", () => {
+    expect(normalizeTenantUrl("nferreira.staging.volterra.us")).toBe(
+      "https://nferreira.staging.volterra.us"
+    );
+  });
+
+  it("should strip /api from URLs that already have it", () => {
+    expect(
+      normalizeTenantUrl("https://tenant.console.ves.volterra.io/api")
+    ).toBe("https://tenant.console.ves.volterra.io");
+  });
+
+  it("should handle protocol-less URL with /api suffix", () => {
+    expect(normalizeTenantUrl("tenant.console.ves.volterra.io/api")).toBe(
+      "https://tenant.console.ves.volterra.io"
+    );
+  });
+
+  it("should handle empty string", () => {
+    expect(normalizeTenantUrl("")).toBe("");
+  });
+
+  it("should handle whitespace-only string", () => {
+    expect(normalizeTenantUrl("   ")).toBe("");
+  });
+
+  it("should trim whitespace and normalize", () => {
+    expect(normalizeTenantUrl("  tenant.console.ves.volterra.io  ")).toBe(
+      "https://tenant.console.ves.volterra.io"
+    );
+  });
+});
+
+describe("extractTenantFromUrl", () => {
+  it("should extract tenant from console URL", () => {
+    expect(
+      extractTenantFromUrl("https://f5-amer-ent.console.ves.volterra.io/api")
+    ).toBe("f5-amer-ent");
+  });
+
+  it("should extract tenant from staging URL", () => {
+    expect(
+      extractTenantFromUrl("https://nferreira.staging.volterra.us/api")
+    ).toBe("nferreira");
+  });
+
+  it("should extract tenant from URL without /api", () => {
+    expect(
+      extractTenantFromUrl("https://mycompany.console.ves.volterra.io")
+    ).toBe("mycompany");
+  });
+
+  it("should return null for malformed URL", () => {
+    expect(extractTenantFromUrl("not-a-valid-url")).toBe(null);
+  });
+
+  it("should return null for empty string", () => {
+    expect(extractTenantFromUrl("")).toBe(null);
+  });
+
+  it("should handle tenant with hyphens", () => {
+    expect(
+      extractTenantFromUrl("https://my-company-name.console.ves.volterra.io/api")
+    ).toBe("my-company-name");
+  });
+
+  it("should handle tenant with numbers", () => {
+    expect(
+      extractTenantFromUrl("https://company123.console.ves.volterra.io/api")
+    ).toBe("company123");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
   AuthMode,
   AUTH_ENV_VARS,
   normalizeApiUrl,
+  normalizeTenantUrl,
   extractTenantFromUrl,
   type Credentials,
 } from "./auth/credential-manager.js";


### PR DESCRIPTION
## Summary

Enhance URL normalization in `@robinmordasiewicz/f5xc-auth` to be the **single source of truth**
for handling all F5XC URL input formats, eliminating the need for workaround normalization in
consumer packages like f5xc-api-mcp.

## Problem

The previous `normalizeApiUrl()` function required URLs to have `https://` prefix for pattern
matching. Users entering these formats got incorrect results:

| Input | Previous Result | Now |
|-------|-----------------|-----|
| `tenant.console.ves.volterra.io` | `tenant.console.ves.volterra.io/api` (broken) | `https://tenant.console.ves.volterra.io/api` |
| `tenant.staging.volterra.us/api` | `tenant.staging.volterra.us/api/api` (broken) | `https://tenant.staging.volterra.us/api` |

## Changes

### Enhanced `normalizeApiUrl()`
- Add `https://` protocol when missing (handles protocol-less URLs)
- Trim whitespace from input
- Handle empty strings gracefully

### New `normalizeTenantUrl()` export
- Returns normalized URL **without** `/api` suffix
- Useful for consumers who add `/api` themselves or for display purposes

### Comprehensive Unit Tests
- 37 new tests covering all URL formats and edge cases

## Test Results

```
✓ src/auth/__tests__/url-normalization.test.ts (37 tests)
Test Files  1 passed (1)
Tests       37 passed (37)
```

## Migration for Consumers

After updating to this version, consumers like f5xc-api-mcp can:
1. Remove workaround URL normalization code
2. Use `normalizeTenantUrl()` if they need the base URL without `/api`
3. Rely on this package as the single source of truth

## Test plan

- [x] All 37 unit tests pass
- [x] TypeScript compiles without errors
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)