### PR TITLE
docs: add Material for MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,70 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION: '3.13'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-docs.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ npm-debug.log*
 
 # Test coverage
 coverage/
+
+# MkDocs build output
+site/

--- a/docs/api/credential-manager.md
+++ b/docs/api/credential-manager.md
@@ -1,0 +1,282 @@
+# CredentialManager
+
+The `CredentialManager` class handles authentication credential resolution and state management.
+
+## Import
+
+```typescript
+import { CredentialManager, AuthMode } from '@robinmordasiewicz/f5xc-auth';
+```
+
+## Constructor
+
+```typescript
+const credentialManager = new CredentialManager();
+```
+
+Creates a new `CredentialManager` instance. Credentials are not loaded until `initialize()` is called.
+
+## Methods
+
+### initialize()
+
+```typescript
+async initialize(): Promise<void>
+```
+
+Loads credentials from environment variables or active profile. Must be called before accessing credentials.
+
+**Example:**
+
+```typescript
+const cm = new CredentialManager();
+await cm.initialize();
+```
+
+### isAuthenticated()
+
+```typescript
+isAuthenticated(): boolean
+```
+
+Returns `true` if valid credentials are loaded.
+
+**Returns:** `boolean`
+
+**Example:**
+
+```typescript
+if (cm.isAuthenticated()) {
+  // Make API calls
+}
+```
+
+### getAuthMode()
+
+```typescript
+getAuthMode(): AuthMode
+```
+
+Returns the current authentication mode.
+
+**Returns:** `AuthMode` - One of:
+
+- `AuthMode.NONE` - No authentication (documentation mode)
+- `AuthMode.TOKEN` - API token authentication
+- `AuthMode.CERTIFICATE` - Certificate/mTLS authentication
+
+**Example:**
+
+```typescript
+const mode = cm.getAuthMode();
+if (mode === AuthMode.TOKEN) {
+  console.log('Using API token authentication');
+}
+```
+
+### getApiUrl()
+
+```typescript
+getApiUrl(): string | null
+```
+
+Returns the normalized API URL with `/api` suffix.
+
+**Returns:** `string | null`
+
+**Example:**
+
+```typescript
+const apiUrl = cm.getApiUrl();
+// Returns: "https://tenant.console.ves.volterra.io/api"
+```
+
+### getTenant()
+
+```typescript
+getTenant(): string | null
+```
+
+Extracts the tenant name from the API URL.
+
+**Returns:** `string | null`
+
+**Example:**
+
+```typescript
+const tenant = cm.getTenant();
+// Returns: "tenant"
+```
+
+### getNamespace()
+
+```typescript
+getNamespace(): string | null
+```
+
+Returns the default namespace.
+
+**Returns:** `string | null`
+
+### getToken()
+
+```typescript
+getToken(): string | null
+```
+
+Returns the API token (for token authentication).
+
+**Returns:** `string | null`
+
+!!! warning "Security"
+    Do not log or expose the token in application output.
+
+### getP12Certificate()
+
+```typescript
+getP12Certificate(): Buffer | null
+```
+
+Returns the P12 certificate buffer (for certificate authentication).
+
+**Returns:** `Buffer | null`
+
+### getCert() / getKey()
+
+```typescript
+getCert(): string | null
+getKey(): string | null
+```
+
+Returns certificate and private key content (for mTLS with separate files).
+
+**Returns:** `string | null`
+
+### getTlsInsecure()
+
+```typescript
+getTlsInsecure(): boolean
+```
+
+Returns whether TLS certificate verification is disabled.
+
+**Returns:** `boolean`
+
+!!! danger "Warning"
+    Only use TLS insecure mode for staging/development environments.
+
+### getCaBundle()
+
+```typescript
+getCaBundle(): Buffer | null
+```
+
+Returns the custom CA bundle for TLS verification.
+
+**Returns:** `Buffer | null`
+
+### getActiveProfile()
+
+```typescript
+getActiveProfile(): string | null
+```
+
+Returns the name of the active profile, or `null` if credentials are from environment variables.
+
+**Returns:** `string | null`
+
+### getCredentials()
+
+```typescript
+getCredentials(): Readonly<Credentials>
+```
+
+Returns a read-only copy of all credentials.
+
+**Returns:** `Readonly<Credentials>`
+
+### reload()
+
+```typescript
+async reload(): Promise<void>
+```
+
+Reloads credentials from environment/profile. Useful when credentials change during runtime.
+
+**Example:**
+
+```typescript
+// After environment changes
+await cm.reload();
+```
+
+## Credential Priority
+
+Credentials are resolved in this order:
+
+1. **Environment Variables** (highest priority)
+2. **Active Profile** from `~/.config/f5xc/`
+3. **Documentation Mode** (no credentials - lowest)
+
+## Types
+
+### AuthMode
+
+```typescript
+enum AuthMode {
+  NONE = "none",
+  TOKEN = "token",
+  CERTIFICATE = "certificate"
+}
+```
+
+### Credentials
+
+```typescript
+interface Credentials {
+  mode: AuthMode;
+  apiUrl: string | null;
+  token: string | null;
+  p12Certificate: Buffer | null;
+  cert: string | null;
+  key: string | null;
+  namespace: string | null;
+  tlsInsecure: boolean;
+  caBundle: Buffer | null;
+}
+```
+
+## Complete Example
+
+```typescript
+import { CredentialManager, AuthMode } from '@robinmordasiewicz/f5xc-auth';
+
+async function checkAuth() {
+  const cm = new CredentialManager();
+  await cm.initialize();
+
+  console.log('Authentication Status:');
+  console.log(`  Mode: ${cm.getAuthMode()}`);
+  console.log(`  Authenticated: ${cm.isAuthenticated()}`);
+
+  if (cm.isAuthenticated()) {
+    console.log(`  Tenant: ${cm.getTenant()}`);
+    console.log(`  API URL: ${cm.getApiUrl()}`);
+    console.log(`  Namespace: ${cm.getNamespace() || 'default'}`);
+
+    const profile = cm.getActiveProfile();
+    if (profile) {
+      console.log(`  Profile: ${profile}`);
+    } else {
+      console.log('  Source: Environment variables');
+    }
+  }
+}
+
+checkAuth();
+```
+
+## Related
+
+- [ProfileManager](profile-manager.md) - Managing stored profiles
+- [HttpClient](http-client.md) - Making authenticated requests

--- a/docs/api/http-client.md
+++ b/docs/api/http-client.md
@@ -1,0 +1,345 @@
+# HttpClient
+
+The `HttpClient` class provides a pre-configured Axios instance for making authenticated API requests to F5 Distributed Cloud.
+
+## Import
+
+```typescript
+import { createHttpClient, CredentialManager } from '@robinmordasiewicz/f5xc-auth';
+```
+
+## Creating an Instance
+
+```typescript
+const credentialManager = new CredentialManager();
+await credentialManager.initialize();
+
+const httpClient = createHttpClient(credentialManager, {
+  timeout: 30000,
+  debug: true
+});
+```
+
+## Constructor Options
+
+```typescript
+interface HttpClientConfig {
+  timeout?: number;          // Request timeout in ms (default: 30000)
+  headers?: Record<string, string>;  // Custom headers
+  debug?: boolean;           // Enable request/response logging
+}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `timeout` | number | 30000 | Request timeout in milliseconds |
+| `headers` | object | {} | Custom headers for all requests |
+| `debug` | boolean | false | Enable debug logging |
+
+## Methods
+
+### isAvailable()
+
+```typescript
+isAvailable(): boolean
+```
+
+Returns `true` if the client has valid credentials and can make requests.
+
+**Example:**
+
+```typescript
+if (!httpClient.isAvailable()) {
+  console.log('Running in documentation mode - API calls disabled');
+}
+```
+
+### get()
+
+<span class="api-method api-method-get">GET</span>
+
+```typescript
+async get<T>(path: string, config?: AxiosRequestConfig): Promise<ApiResponse<T>>
+```
+
+Makes a GET request.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | API endpoint path |
+| `config` | AxiosRequestConfig | Optional Axios config |
+
+**Example:**
+
+```typescript
+const response = await httpClient.get('/web/namespaces');
+console.log(response.data);
+```
+
+### post()
+
+<span class="api-method api-method-post">POST</span>
+
+```typescript
+async post<T>(path: string, data?: unknown, config?: AxiosRequestConfig): Promise<ApiResponse<T>>
+```
+
+Makes a POST request.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | API endpoint path |
+| `data` | unknown | Request body |
+| `config` | AxiosRequestConfig | Optional Axios config |
+
+**Example:**
+
+```typescript
+const response = await httpClient.post('/config/namespaces', {
+  metadata: { name: 'my-namespace' },
+  spec: {}
+});
+```
+
+### put()
+
+<span class="api-method api-method-put">PUT</span>
+
+```typescript
+async put<T>(path: string, data?: unknown, config?: AxiosRequestConfig): Promise<ApiResponse<T>>
+```
+
+Makes a PUT request.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | API endpoint path |
+| `data` | unknown | Request body |
+| `config` | AxiosRequestConfig | Optional Axios config |
+
+### delete()
+
+<span class="api-method api-method-delete">DELETE</span>
+
+```typescript
+async delete<T>(path: string, config?: AxiosRequestConfig): Promise<ApiResponse<T>>
+```
+
+Makes a DELETE request.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | string | API endpoint path |
+| `config` | AxiosRequestConfig | Optional Axios config |
+
+### getAxiosInstance()
+
+```typescript
+getAxiosInstance(): AxiosInstance | null
+```
+
+Returns the underlying Axios instance for advanced usage.
+
+**Example:**
+
+```typescript
+const axios = httpClient.getAxiosInstance();
+if (axios) {
+  // Use Axios directly
+  axios.interceptors.request.use(config => {
+    console.log('Request:', config.url);
+    return config;
+  });
+}
+```
+
+## Response Format
+
+All request methods return an `ApiResponse` object:
+
+```typescript
+interface ApiResponse<T> {
+  data: T;                    // Response data
+  status: number;             // HTTP status code
+  headers: Record<string, string>;  // Response headers
+  duration: number;           // Request duration in ms
+}
+```
+
+**Example:**
+
+```typescript
+const response = await httpClient.get('/web/namespaces');
+console.log(`Status: ${response.status}`);
+console.log(`Duration: ${response.duration}ms`);
+console.log(`Data:`, response.data);
+```
+
+## Error Handling
+
+The client throws typed errors for different failure scenarios:
+
+```typescript
+import { F5XCApiError, AuthenticationError } from '@robinmordasiewicz/f5xc-auth';
+
+try {
+  const response = await httpClient.get('/web/namespaces');
+} catch (error) {
+  if (error instanceof AuthenticationError) {
+    console.error('Authentication failed:', error.message);
+  } else if (error instanceof F5XCApiError) {
+    console.error(`API error (${error.status}):`, error.message);
+    console.error('Response data:', error.data);
+  } else {
+    console.error('Unknown error:', error);
+  }
+}
+```
+
+### Error Types
+
+#### AuthenticationError
+
+Thrown when credentials are missing or invalid:
+
+```typescript
+class AuthenticationError extends Error {
+  constructor(message: string);
+}
+```
+
+#### F5XCApiError
+
+Thrown for API response errors:
+
+```typescript
+class F5XCApiError extends Error {
+  status?: number;
+  data?: unknown;
+  constructor(message: string, status?: number, data?: unknown);
+}
+```
+
+## TLS Configuration
+
+The client automatically configures TLS based on credentials:
+
+### Custom CA Bundle
+
+```typescript
+// Set via environment
+export F5XC_CA_BUNDLE=/path/to/ca-bundle.crt
+
+// Or in profile
+{
+  "name": "enterprise",
+  "apiUrl": "https://tenant.console.ves.volterra.io",
+  "apiToken": "...",
+  "caBundle": "/path/to/ca-bundle.crt"
+}
+```
+
+### Insecure Mode
+
+!!! danger "Warning"
+    Only use for staging/development environments!
+
+```typescript
+// Set via environment
+export F5XC_TLS_INSECURE=true
+
+// Or in profile
+{
+  "name": "staging",
+  "apiUrl": "https://staging.console.ves.volterra.io",
+  "apiToken": "...",
+  "tlsInsecure": true
+}
+```
+
+## Authentication Modes
+
+The client automatically configures authentication based on credentials:
+
+### Token Authentication
+
+```typescript
+// Headers set automatically:
+// Authorization: APIToken <token>
+```
+
+### Certificate Authentication (mTLS)
+
+```typescript
+// HTTPS agent configured with:
+// - pfx: P12 certificate buffer, or
+// - cert/key: Certificate and private key
+```
+
+## Complete Example
+
+```typescript
+import {
+  CredentialManager,
+  createHttpClient,
+  F5XCApiError,
+  AuthenticationError
+} from '@robinmordasiewicz/f5xc-auth';
+
+async function listNamespaces() {
+  // Initialize credentials
+  const cm = new CredentialManager();
+  await cm.initialize();
+
+  // Create HTTP client
+  const client = createHttpClient(cm, {
+    timeout: 60000,
+    debug: process.env.DEBUG === 'true'
+  });
+
+  // Check availability
+  if (!client.isAvailable()) {
+    console.log('No credentials configured');
+    console.log('Set F5XC_API_URL and F5XC_API_TOKEN to enable API calls');
+    return;
+  }
+
+  try {
+    // Make request
+    const response = await client.get<{ items: Array<{ name: string }> }>(
+      '/web/namespaces'
+    );
+
+    console.log(`Found ${response.data.items?.length || 0} namespaces`);
+    console.log(`Request took ${response.duration}ms`);
+
+    response.data.items?.forEach(ns => {
+      console.log(`  - ${ns.name}`);
+    });
+
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      console.error('Auth error:', error.message);
+    } else if (error instanceof F5XCApiError) {
+      console.error(`API error ${error.status}:`, error.message);
+    } else {
+      throw error;
+    }
+  }
+}
+
+listNamespaces();
+```
+
+## Related
+
+- [CredentialManager](credential-manager.md) - Credential management
+- [Configuration](../getting-started/configuration.md) - HTTP client options

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,119 @@
+# API Reference
+
+Complete API documentation for `@robinmordasiewicz/f5xc-auth`.
+
+## Overview
+
+The library exports three main components:
+
+| Component | Description |
+|-----------|-------------|
+| [CredentialManager](credential-manager.md) | Manages authentication state and credential resolution |
+| [ProfileManager](profile-manager.md) | Handles profile CRUD operations and storage |
+| [HttpClient](http-client.md) | Pre-configured Axios client with auth headers |
+
+## Quick Reference
+
+### Imports
+
+```typescript
+// Main exports
+import {
+  CredentialManager,
+  createHttpClient,
+  getProfileManager
+} from '@robinmordasiewicz/f5xc-auth';
+
+// Types
+import type {
+  Profile,
+  ProfileConfig,
+  ProfileResult,
+  Credentials,
+  AuthMode,
+  HttpClientConfig,
+  ApiResponse
+} from '@robinmordasiewicz/f5xc-auth';
+
+// Utility functions
+import {
+  normalizeApiUrl,
+  normalizeTenantUrl,
+  extractTenantFromUrl
+} from '@robinmordasiewicz/f5xc-auth';
+```
+
+### Authentication Modes
+
+```typescript
+enum AuthMode {
+  NONE = "none",           // Documentation mode
+  TOKEN = "token",         // API token authentication
+  CERTIFICATE = "certificate"  // mTLS authentication
+}
+```
+
+## Module Structure
+
+```
+@robinmordasiewicz/f5xc-auth
+├── CredentialManager     # Auth state management
+│   ├── initialize()
+│   ├── isAuthenticated()
+│   ├── getAuthMode()
+│   ├── getApiUrl()
+│   ├── getTenant()
+│   └── ...
+├── ProfileManager        # Profile storage
+│   ├── list()
+│   ├── get()
+│   ├── save()
+│   ├── delete()
+│   ├── setActive()
+│   └── ...
+├── HttpClient           # API requests
+│   ├── get()
+│   ├── post()
+│   ├── put()
+│   ├── delete()
+│   └── ...
+└── Utilities
+    ├── normalizeApiUrl()
+    ├── normalizeTenantUrl()
+    └── extractTenantFromUrl()
+```
+
+## Environment Variables
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `F5XC_API_URL` | string | F5 XC tenant URL |
+| `F5XC_API_TOKEN` | string | API token |
+| `F5XC_P12_BUNDLE` | string | Path to P12 certificate |
+| `F5XC_CERT` | string | Path to certificate file |
+| `F5XC_KEY` | string | Path to private key file |
+| `F5XC_NAMESPACE` | string | Default namespace |
+| `F5XC_TLS_INSECURE` | boolean | Disable TLS verification |
+| `F5XC_CA_BUNDLE` | string | Path to custom CA bundle |
+
+## Error Types
+
+```typescript
+// API request errors
+class F5XCApiError extends Error {
+  status?: number;
+  data?: unknown;
+}
+
+// Authentication errors
+class AuthenticationError extends Error {}
+
+// SSL/TLS errors (wrapped with guidance)
+class SSLError extends Error {}
+```
+
+## Next Steps
+
+- [CredentialManager](credential-manager.md) - Full credential management API
+- [ProfileManager](profile-manager.md) - Profile storage and switching
+- [HttpClient](http-client.md) - Making authenticated API requests

--- a/docs/api/profile-manager.md
+++ b/docs/api/profile-manager.md
@@ -1,0 +1,346 @@
+# ProfileManager
+
+The `ProfileManager` class handles profile CRUD operations with secure XDG-compliant file storage.
+
+## Import
+
+```typescript
+import { getProfileManager } from '@robinmordasiewicz/f5xc-auth';
+```
+
+## Getting the Instance
+
+The `ProfileManager` uses a singleton pattern. Use `getProfileManager()` to get the shared instance:
+
+```typescript
+const profileManager = getProfileManager();
+```
+
+## Methods
+
+### list()
+
+```typescript
+async list(): Promise<Profile[]>
+```
+
+Lists all saved profiles, sorted alphabetically by name.
+
+**Returns:** `Profile[]`
+
+**Example:**
+
+```typescript
+const profiles = await profileManager.list();
+profiles.forEach(p => console.log(p.name));
+```
+
+### get()
+
+```typescript
+async get(name: string): Promise<Profile | null>
+```
+
+Gets a profile by name. Supports both JSON and YAML profile files.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Profile name |
+
+**Returns:** `Profile | null`
+
+**Example:**
+
+```typescript
+const profile = await profileManager.get('production');
+if (profile) {
+  console.log(profile.apiUrl);
+}
+```
+
+### save()
+
+```typescript
+async save(profile: Profile): Promise<ProfileResult>
+```
+
+Saves a new profile or updates an existing one.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `profile` | Profile | Profile data to save |
+
+**Returns:** `ProfileResult`
+
+**Validation Rules:**
+
+- Name: alphanumeric, dashes, underscores only (max 64 chars)
+- API URL: Must be valid HTTP/HTTPS URL
+- Authentication: At least one auth method required
+
+**Example:**
+
+```typescript
+const result = await profileManager.save({
+  name: 'production',
+  apiUrl: 'https://mytenant.console.ves.volterra.io',
+  apiToken: 'my-api-token',
+  defaultNamespace: 'my-namespace'
+});
+
+if (result.success) {
+  console.log(result.message);
+} else {
+  console.error('Failed:', result.message);
+}
+```
+
+### delete()
+
+```typescript
+async delete(name: string): Promise<ProfileResult>
+```
+
+Deletes a profile by name.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Profile name to delete |
+
+**Returns:** `ProfileResult`
+
+!!! note
+    Cannot delete the currently active profile. Switch to another profile first.
+
+**Example:**
+
+```typescript
+const result = await profileManager.delete('old-profile');
+if (!result.success) {
+  console.error(result.message);
+}
+```
+
+### setActive()
+
+```typescript
+async setActive(name: string): Promise<ProfileResult>
+```
+
+Sets a profile as the active profile.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Profile name to activate |
+
+**Returns:** `ProfileResult`
+
+**Example:**
+
+```typescript
+const result = await profileManager.setActive('production');
+if (result.success) {
+  console.log('Switched to production profile');
+}
+```
+
+### getActive()
+
+```typescript
+async getActive(): Promise<string | null>
+```
+
+Gets the name of the currently active profile.
+
+**Returns:** `string | null`
+
+**Example:**
+
+```typescript
+const activeName = await profileManager.getActive();
+console.log(`Active profile: ${activeName || 'none'}`);
+```
+
+### getActiveProfile()
+
+```typescript
+async getActiveProfile(): Promise<Profile | null>
+```
+
+Gets the full profile data for the active profile.
+
+**Returns:** `Profile | null`
+
+**Example:**
+
+```typescript
+const profile = await profileManager.getActiveProfile();
+if (profile) {
+  console.log(`Connected to: ${profile.apiUrl}`);
+}
+```
+
+### exists()
+
+```typescript
+async exists(name: string): Promise<boolean>
+```
+
+Checks if a profile exists.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Profile name to check |
+
+**Returns:** `boolean`
+
+### maskProfile()
+
+```typescript
+maskProfile(profile: Profile): Record<string, string>
+```
+
+Returns a profile with sensitive fields masked for display.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `profile` | Profile | Profile to mask |
+
+**Returns:** `Record<string, string>`
+
+**Example:**
+
+```typescript
+const profile = await profileManager.get('production');
+if (profile) {
+  const masked = profileManager.maskProfile(profile);
+  console.log(masked);
+  // { name: 'production', apiUrl: '...', apiToken: '****abcd' }
+}
+```
+
+## Types
+
+### Profile
+
+```typescript
+interface Profile {
+  name: string;
+  apiUrl: string;
+  apiToken?: string;
+  p12Bundle?: string;
+  cert?: string;
+  key?: string;
+  defaultNamespace?: string;
+  tlsInsecure?: boolean;
+  caBundle?: string;
+}
+```
+
+### ProfileResult
+
+```typescript
+interface ProfileResult {
+  success: boolean;
+  message: string;
+  profile?: Profile;
+  profiles?: Profile[];
+}
+```
+
+### ProfileConfig
+
+```typescript
+interface ProfileConfig {
+  configDir: string;
+  profilesDir: string;
+  activeProfileFile: string;
+}
+```
+
+## Storage Location
+
+Profiles are stored in XDG-compliant directories:
+
+| Platform | Location |
+|----------|----------|
+| Linux/macOS | `~/.config/f5xc/profiles/` |
+| Windows | `%APPDATA%\f5xc\profiles\` |
+
+### File Format
+
+Profiles are stored as JSON files with `0600` permissions:
+
+```json
+{
+  "name": "production",
+  "apiUrl": "https://mytenant.console.ves.volterra.io",
+  "apiToken": "your-api-token",
+  "defaultNamespace": "my-namespace"
+}
+```
+
+YAML format is also supported for reading:
+
+```yaml
+name: production
+api_url: https://mytenant.console.ves.volterra.io
+api_token: your-api-token
+default_namespace: my-namespace
+```
+
+## Complete Example
+
+```typescript
+import { getProfileManager } from '@robinmordasiewicz/f5xc-auth';
+
+async function manageProfiles() {
+  const pm = getProfileManager();
+
+  // List existing profiles
+  const profiles = await pm.list();
+  console.log('Existing profiles:', profiles.map(p => p.name));
+
+  // Create a new profile
+  const saveResult = await pm.save({
+    name: 'staging',
+    apiUrl: 'https://staging.console.ves.volterra.io',
+    apiToken: process.env.STAGING_TOKEN!,
+    defaultNamespace: 'test'
+  });
+
+  if (!saveResult.success) {
+    console.error('Failed to save:', saveResult.message);
+    return;
+  }
+
+  // Set as active
+  await pm.setActive('staging');
+
+  // Get current active profile
+  const active = await pm.getActiveProfile();
+  if (active) {
+    const masked = pm.maskProfile(active);
+    console.log('Active profile:', masked);
+  }
+}
+
+manageProfiles();
+```
+
+## Related
+
+- [CredentialManager](credential-manager.md) - Using credentials
+- [Configuration Guide](../getting-started/configuration.md) - Profile format details

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,163 @@
+# Configuration
+
+This guide covers all configuration options for `f5xc-auth`.
+
+## Profile Location
+
+Profiles are stored in XDG-compliant directories:
+
+| Platform | Location |
+|----------|----------|
+| Linux | `~/.config/f5xc/profiles/` |
+| macOS | `~/.config/f5xc/profiles/` |
+| Windows | `%APPDATA%\f5xc\profiles\` |
+
+## Profile Schema
+
+A profile is a JSON file with the following structure:
+
+```json
+{
+  "name": "production",
+  "apiUrl": "https://mytenant.console.ves.volterra.io",
+  "apiToken": "your-api-token",
+  "defaultNamespace": "my-namespace",
+  "tlsInsecure": false,
+  "caBundle": "/path/to/ca-bundle.crt"
+}
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Unique profile identifier |
+| `apiUrl` | string | F5 XC tenant URL |
+
+### Authentication Fields
+
+You must provide one of the following authentication methods:
+
+=== "API Token"
+
+    ```json
+    {
+      "name": "token-auth",
+      "apiUrl": "https://mytenant.console.ves.volterra.io",
+      "apiToken": "your-api-token"
+    }
+    ```
+
+=== "P12 Certificate"
+
+    ```json
+    {
+      "name": "p12-auth",
+      "apiUrl": "https://mytenant.console.ves.volterra.io",
+      "p12Bundle": "/path/to/certificate.p12"
+    }
+    ```
+
+=== "Cert + Key"
+
+    ```json
+    {
+      "name": "cert-auth",
+      "apiUrl": "https://mytenant.console.ves.volterra.io",
+      "cert": "/path/to/certificate.pem",
+      "key": "/path/to/private-key.pem"
+    }
+    ```
+
+### Optional Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `defaultNamespace` | string | - | Default namespace for API operations |
+| `tlsInsecure` | boolean | `false` | Disable TLS verification (staging only) |
+| `caBundle` | string | - | Path to custom CA bundle |
+
+## Environment Variables
+
+Environment variables override profile settings:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `F5XC_API_URL` | Tenant URL | `https://mytenant.console.ves.volterra.io` |
+| `F5XC_API_TOKEN` | API token | `your-api-token` |
+| `F5XC_P12_BUNDLE` | P12 certificate path | `/path/to/cert.p12` |
+| `F5XC_CERT` | Certificate file path | `/path/to/cert.pem` |
+| `F5XC_KEY` | Private key file path | `/path/to/key.pem` |
+| `F5XC_NAMESPACE` | Default namespace | `my-namespace` |
+| `F5XC_TLS_INSECURE` | Disable TLS verification | `true` |
+| `F5XC_CA_BUNDLE` | Custom CA bundle path | `/path/to/ca-bundle.crt` |
+
+### Priority Order
+
+1. **Environment Variables** (highest)
+2. **Active Profile**
+3. **Documentation Mode** (no credentials)
+
+## URL Normalization
+
+The library automatically normalizes various URL formats:
+
+| Input | Normalized Output |
+|-------|-------------------|
+| `mytenant` | `https://mytenant.console.ves.volterra.io` |
+| `mytenant.console.ves.volterra.io` | `https://mytenant.console.ves.volterra.io` |
+| `https://mytenant.console.ves.volterra.io/` | `https://mytenant.console.ves.volterra.io` |
+
+## Security Configuration
+
+### File Permissions
+
+Profile files are created with secure permissions:
+
+- **Profile files**: `0600` (owner read/write only)
+- **Config directory**: `0700` (owner access only)
+
+### Token Masking
+
+When displaying credentials, tokens are masked to show only the last 4 characters:
+
+```
+Token: ****-****-****-abcd
+```
+
+### TLS Configuration
+
+!!! warning "Insecure Mode"
+    Only enable `tlsInsecure` for staging/development environments. Never use in production.
+
+For enterprise environments with custom CA certificates:
+
+```json
+{
+  "name": "enterprise",
+  "apiUrl": "https://mytenant.console.ves.volterra.io",
+  "apiToken": "your-token",
+  "caBundle": "/etc/pki/tls/certs/enterprise-ca.crt"
+}
+```
+
+## HTTP Client Configuration
+
+The HTTP client accepts additional options:
+
+```typescript
+import { createHttpClient } from '@robinmordasiewicz/f5xc-auth';
+
+const httpClient = createHttpClient(credentialManager, {
+  timeout: 30000,      // Request timeout in ms
+  debug: true,         // Enable debug logging
+  retries: 3,          // Number of retry attempts
+  retryDelay: 1000     // Delay between retries in ms
+});
+```
+
+## Next Steps
+
+- [Authentication Methods](../guides/authentication.md) - Detailed auth method guide
+- [Profile Management](../guides/profiles.md) - Advanced profile operations
+- [API Reference](../api/index.md) - Complete API documentation

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,60 @@
+# Getting Started
+
+This guide will help you install and configure `@robinmordasiewicz/f5xc-auth` for your F5 Distributed Cloud projects.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- **Node.js 18** or later installed
+- **npm** or **yarn** package manager
+- **F5 Distributed Cloud** tenant access with valid credentials
+
+## What You'll Learn
+
+1. [Installation](installation.md) - How to install the package
+2. [Quick Start](quickstart.md) - Basic usage and first steps
+3. [Configuration](configuration.md) - Profile setup and environment variables
+
+## Overview
+
+The `f5xc-auth` library provides three main components:
+
+| Component | Purpose |
+|-----------|---------|
+| **CredentialManager** | Manages authentication state and credential resolution |
+| **ProfileManager** | Handles profile CRUD operations and storage |
+| **HttpClient** | Pre-configured Axios client with auth headers |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Your Application                    │
+├─────────────────────────────────────────────────────┤
+│                    f5xc-auth                         │
+│  ┌──────────────┬──────────────┬──────────────────┐ │
+│  │ Credential   │   Profile    │    HTTP          │ │
+│  │ Manager      │   Manager    │    Client        │ │
+│  └──────┬───────┴──────┬───────┴────────┬─────────┘ │
+│         │              │                │           │
+│         ▼              ▼                ▼           │
+│  ┌──────────────────────────────────────────────┐  │
+│  │           ~/.config/f5xc/profiles/           │  │
+│  └──────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+## Credential Priority
+
+The library resolves credentials in the following order:
+
+1. **Environment Variables** (highest priority)
+2. **Active Profile** from `~/.config/f5xc/`
+3. **Documentation Mode** (no credentials - lowest priority)
+
+This allows you to override profile settings in CI/CD pipelines while maintaining local development profiles.
+
+## Next Steps
+
+Start with the [Installation Guide](installation.md) to add the package to your project.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,70 @@
+# Installation
+
+## Package Manager
+
+=== "npm"
+
+    ```bash
+    npm install @robinmordasiewicz/f5xc-auth
+    ```
+
+=== "yarn"
+
+    ```bash
+    yarn add @robinmordasiewicz/f5xc-auth
+    ```
+
+=== "pnpm"
+
+    ```bash
+    pnpm add @robinmordasiewicz/f5xc-auth
+    ```
+
+## Requirements
+
+| Requirement | Version |
+|-------------|---------|
+| Node.js | >= 18.0.0 |
+| TypeScript | >= 5.0 (optional) |
+
+## Dependencies
+
+The library has minimal dependencies:
+
+- **axios** - HTTP client for API requests
+- **yaml** - YAML parsing for configuration files
+
+## TypeScript Support
+
+Full TypeScript support is included out of the box. Type definitions are bundled with the package.
+
+```typescript
+import type { Profile, ProfileConfig } from '@robinmordasiewicz/f5xc-auth';
+```
+
+## ESM Module
+
+This package is distributed as an ES Module. Ensure your project is configured for ESM:
+
+```json title="package.json"
+{
+  "type": "module"
+}
+```
+
+Or use the `.mjs` extension for your files.
+
+## Verify Installation
+
+After installation, verify the package is working:
+
+```typescript
+import { CredentialManager } from '@robinmordasiewicz/f5xc-auth';
+
+const cm = new CredentialManager();
+console.log('f5xc-auth installed successfully!');
+```
+
+## Next Steps
+
+Continue to the [Quick Start Guide](quickstart.md) to learn basic usage.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,152 @@
+# Quick Start
+
+This guide walks you through basic usage of `f5xc-auth` to authenticate with F5 Distributed Cloud.
+
+## Basic Authentication
+
+The simplest way to authenticate is using the `CredentialManager`:
+
+```typescript
+import { CredentialManager } from '@robinmordasiewicz/f5xc-auth';
+
+async function main() {
+  const credentialManager = new CredentialManager();
+  await credentialManager.initialize();
+
+  if (credentialManager.isAuthenticated()) {
+    console.log(`Tenant: ${credentialManager.getTenant()}`);
+    console.log(`API URL: ${credentialManager.getApiUrl()}`);
+    console.log(`Namespace: ${credentialManager.getNamespace()}`);
+  } else {
+    console.log('Not authenticated');
+  }
+}
+
+main();
+```
+
+## Create Your First Profile
+
+Profiles store your F5 XC credentials. Create one using the `ProfileManager`:
+
+```typescript
+import { getProfileManager } from '@robinmordasiewicz/f5xc-auth';
+
+async function createProfile() {
+  const profileManager = getProfileManager();
+
+  await profileManager.save({
+    name: 'my-tenant',
+    apiUrl: 'https://mytenant.console.ves.volterra.io',
+    apiToken: 'your-api-token-here',
+    defaultNamespace: 'default'
+  });
+
+  // Set as active profile
+  await profileManager.setActive('my-tenant');
+
+  console.log('Profile created and activated!');
+}
+
+createProfile();
+```
+
+## Make API Requests
+
+Use the HTTP client to make authenticated requests:
+
+```typescript
+import { CredentialManager, createHttpClient } from '@robinmordasiewicz/f5xc-auth';
+
+async function fetchNamespaces() {
+  const credentialManager = new CredentialManager();
+  await credentialManager.initialize();
+
+  const httpClient = createHttpClient(credentialManager);
+
+  if (httpClient.isAvailable()) {
+    const response = await httpClient.get('/web/namespaces');
+    console.log('Namespaces:', response.data);
+  }
+}
+
+fetchNamespaces();
+```
+
+## Using Environment Variables
+
+You can authenticate using environment variables instead of profiles:
+
+```bash
+export F5XC_API_URL="https://mytenant.console.ves.volterra.io"
+export F5XC_API_TOKEN="your-api-token"
+export F5XC_NAMESPACE="default"
+```
+
+Then in your code:
+
+```typescript
+import { CredentialManager } from '@robinmordasiewicz/f5xc-auth';
+
+const credentialManager = new CredentialManager();
+await credentialManager.initialize();
+
+// Credentials are automatically loaded from environment
+console.log(credentialManager.isAuthenticated()); // true
+```
+
+## Complete Example
+
+Here's a complete example that checks authentication and makes a request:
+
+```typescript
+import {
+  CredentialManager,
+  createHttpClient,
+  getProfileManager
+} from '@robinmordasiewicz/f5xc-auth';
+
+async function main() {
+  // Initialize credential manager
+  const credentialManager = new CredentialManager();
+  await credentialManager.initialize();
+
+  // Check authentication status
+  if (!credentialManager.isAuthenticated()) {
+    console.log('No credentials found. Creating profile...');
+
+    const profileManager = getProfileManager();
+    await profileManager.save({
+      name: 'demo',
+      apiUrl: process.env.F5XC_API_URL || 'https://demo.console.ves.volterra.io',
+      apiToken: process.env.F5XC_API_TOKEN || 'your-token',
+      defaultNamespace: 'default'
+    });
+    await profileManager.setActive('demo');
+
+    // Re-initialize to pick up new profile
+    await credentialManager.initialize();
+  }
+
+  // Create HTTP client
+  const httpClient = createHttpClient(credentialManager);
+
+  if (httpClient.isAvailable()) {
+    try {
+      // Fetch namespaces
+      const response = await httpClient.get('/web/namespaces');
+      console.log('Available namespaces:', response.data.items?.length || 0);
+    } catch (error) {
+      console.error('API request failed:', error.message);
+    }
+  }
+}
+
+main();
+```
+
+## Next Steps
+
+- [Configuration](configuration.md) - Learn about all configuration options
+- [Authentication Methods](../guides/authentication.md) - Explore different auth methods
+- [API Reference](../api/index.md) - Full API documentation

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -1,0 +1,214 @@
+# Authentication Methods
+
+This guide covers the different authentication methods supported by `f5xc-auth`.
+
+## Overview
+
+F5 Distributed Cloud supports three authentication methods:
+
+| Method | Use Case | Security Level |
+|--------|----------|----------------|
+| **API Token** | Most common, easy to manage | High |
+| **P12 Certificate** | Legacy, certificate-based | Very High |
+| **Cert + Key** | mTLS with separate files | Very High |
+
+## API Token Authentication
+
+API tokens are the most common and recommended authentication method.
+
+### Getting an API Token
+
+1. Log in to your F5 XC Console
+2. Navigate to **Administration** > **Personal Management** > **Credentials**
+3. Click **Add Credentials**
+4. Select **API Token**
+5. Set an expiration date and click **Generate**
+6. Copy the token immediately (it won't be shown again)
+
+### Using API Tokens
+
+=== "Profile"
+
+    ```json
+    {
+      "name": "production",
+      "apiUrl": "https://mytenant.console.ves.volterra.io",
+      "apiToken": "your-api-token-here"
+    }
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    export F5XC_API_URL="https://mytenant.console.ves.volterra.io"
+    export F5XC_API_TOKEN="your-api-token-here"
+    ```
+
+=== "Code"
+
+    ```typescript
+    import { getProfileManager } from '@robinmordasiewicz/f5xc-auth';
+
+    const pm = getProfileManager();
+    await pm.save({
+      name: 'my-profile',
+      apiUrl: 'https://mytenant.console.ves.volterra.io',
+      apiToken: 'your-api-token-here'
+    });
+    ```
+
+### Token Best Practices
+
+- Set appropriate expiration dates
+- Rotate tokens regularly
+- Use different tokens for different environments
+- Never commit tokens to version control
+
+## P12 Certificate Authentication
+
+P12 (PKCS#12) certificates provide certificate-based mTLS authentication.
+
+### Getting a P12 Certificate
+
+1. Log in to your F5 XC Console
+2. Navigate to **Administration** > **Personal Management** > **Credentials**
+3. Click **Add Credentials**
+4. Select **API Certificate**
+5. Download the P12 file and note the password (if any)
+
+### Using P12 Certificates
+
+=== "Profile"
+
+    ```json
+    {
+      "name": "cert-auth",
+      "apiUrl": "https://mytenant.console.ves.volterra.io",
+      "p12Bundle": "/path/to/certificate.p12"
+    }
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    export F5XC_API_URL="https://mytenant.console.ves.volterra.io"
+    export F5XC_P12_BUNDLE="/path/to/certificate.p12"
+    ```
+
+!!! note "Password Support"
+    F5 XC P12 certificates typically don't require a password. If your P12 file has a password, you may need to extract the cert/key separately.
+
+## Certificate + Key Authentication
+
+For mTLS with separate certificate and private key files.
+
+### Extracting from P12
+
+If you have a P12 file, you can extract the certificate and key:
+
+```bash
+# Extract certificate
+openssl pkcs12 -in certificate.p12 -clcerts -nokeys -out cert.pem
+
+# Extract private key
+openssl pkcs12 -in certificate.p12 -nocerts -nodes -out key.pem
+```
+
+### Using Cert + Key
+
+=== "Profile"
+
+    ```json
+    {
+      "name": "mtls-auth",
+      "apiUrl": "https://mytenant.console.ves.volterra.io",
+      "cert": "/path/to/cert.pem",
+      "key": "/path/to/key.pem"
+    }
+    ```
+
+=== "Environment Variable"
+
+    ```bash
+    export F5XC_API_URL="https://mytenant.console.ves.volterra.io"
+    export F5XC_CERT="/path/to/cert.pem"
+    export F5XC_KEY="/path/to/key.pem"
+    ```
+
+## Authentication Priority
+
+When multiple authentication methods are configured, they're used in this order:
+
+1. **API Token** (if both token and certificate are provided)
+2. **P12 Certificate**
+3. **Cert + Key pair**
+
+## Checking Authentication Status
+
+```typescript
+import { CredentialManager, AuthMode } from '@robinmordasiewicz/f5xc-auth';
+
+const cm = new CredentialManager();
+await cm.initialize();
+
+console.log('Authenticated:', cm.isAuthenticated());
+console.log('Auth Mode:', cm.getAuthMode());
+
+switch (cm.getAuthMode()) {
+  case AuthMode.TOKEN:
+    console.log('Using API token authentication');
+    break;
+  case AuthMode.CERTIFICATE:
+    console.log('Using certificate authentication');
+    break;
+  case AuthMode.NONE:
+    console.log('No authentication (documentation mode)');
+    break;
+}
+```
+
+## Fallback Behavior
+
+The library supports automatic fallback when a certificate fails to load:
+
+```typescript
+// If P12 certificate fails to load but apiToken is also provided,
+// the library will fall back to token authentication
+{
+  "name": "fallback-profile",
+  "apiUrl": "https://tenant.console.ves.volterra.io",
+  "p12Bundle": "/path/to/certificate.p12",  // Primary
+  "apiToken": "backup-token"                  // Fallback
+}
+```
+
+## Troubleshooting
+
+### Token Authentication Issues
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| 401 Unauthorized | Invalid or expired token | Regenerate token in F5 XC Console |
+| Token not recognized | Wrong format | Ensure token starts with correct prefix |
+
+### Certificate Authentication Issues
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Certificate not found | Wrong path | Verify file path exists |
+| Invalid certificate | Corrupt or wrong format | Re-download from F5 XC Console |
+| TLS handshake failure | Certificate/key mismatch | Verify cert and key are paired |
+
+### Debug Mode
+
+Enable debug mode to see authentication details:
+
+```typescript
+const client = createHttpClient(cm, { debug: true });
+```
+
+Or set the environment variable:
+
+```bash
+export DEBUG=true
+```

--- a/docs/guides/environment.md
+++ b/docs/guides/environment.md
@@ -1,0 +1,281 @@
+# Environment Variables
+
+This guide covers using environment variables to configure authentication for CI/CD pipelines and containerized deployments.
+
+## Overview
+
+Environment variables provide a flexible way to configure credentials without storing them in files. They take priority over profile settings.
+
+## Available Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `F5XC_API_URL` | Yes | F5 XC tenant URL |
+| `F5XC_API_TOKEN` | Conditional | API token (if using token auth) |
+| `F5XC_P12_BUNDLE` | Conditional | Path to P12 certificate |
+| `F5XC_CERT` | Conditional | Path to certificate file |
+| `F5XC_KEY` | Conditional | Path to private key file |
+| `F5XC_NAMESPACE` | No | Default namespace |
+| `F5XC_TLS_INSECURE` | No | Disable TLS verification |
+| `F5XC_CA_BUNDLE` | No | Path to custom CA bundle |
+
+## Basic Usage
+
+### API Token
+
+```bash
+export F5XC_API_URL="https://mytenant.console.ves.volterra.io"
+export F5XC_API_TOKEN="your-api-token"
+export F5XC_NAMESPACE="my-namespace"  # Optional
+```
+
+### P12 Certificate
+
+```bash
+export F5XC_API_URL="https://mytenant.console.ves.volterra.io"
+export F5XC_P12_BUNDLE="/path/to/certificate.p12"
+```
+
+### Certificate + Key
+
+```bash
+export F5XC_API_URL="https://mytenant.console.ves.volterra.io"
+export F5XC_CERT="/path/to/cert.pem"
+export F5XC_KEY="/path/to/key.pem"
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml title=".github/workflows/deploy.yml"
+name: Deploy
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
+      F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
+      F5XC_NAMESPACE: ${{ vars.F5XC_NAMESPACE }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run deployment
+        run: npm run deploy
+```
+
+### GitLab CI
+
+```yaml title=".gitlab-ci.yml"
+variables:
+  F5XC_API_URL: $F5XC_API_URL
+  F5XC_API_TOKEN: $F5XC_API_TOKEN
+
+deploy:
+  stage: deploy
+  script:
+    - npm ci
+    - npm run deploy
+```
+
+### Jenkins
+
+```groovy title="Jenkinsfile"
+pipeline {
+    agent any
+
+    environment {
+        F5XC_API_URL = credentials('f5xc-api-url')
+        F5XC_API_TOKEN = credentials('f5xc-api-token')
+    }
+
+    stages {
+        stage('Deploy') {
+            steps {
+                sh 'npm ci'
+                sh 'npm run deploy'
+            }
+        }
+    }
+}
+```
+
+## Docker Integration
+
+### Dockerfile
+
+```dockerfile title="Dockerfile"
+FROM node:20-alpine
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY . .
+
+# Credentials passed at runtime, not build time
+CMD ["node", "dist/index.js"]
+```
+
+### Docker Compose
+
+```yaml title="docker-compose.yml"
+services:
+  app:
+    build: .
+    environment:
+      - F5XC_API_URL=${F5XC_API_URL}
+      - F5XC_API_TOKEN=${F5XC_API_TOKEN}
+      - F5XC_NAMESPACE=${F5XC_NAMESPACE:-default}
+```
+
+### Docker Run
+
+```bash
+docker run -e F5XC_API_URL="https://tenant.console.ves.volterra.io" \
+           -e F5XC_API_TOKEN="your-token" \
+           myapp
+```
+
+## Kubernetes Integration
+
+### Secret
+
+```yaml title="secret.yaml"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: f5xc-credentials
+type: Opaque
+stringData:
+  F5XC_API_URL: "https://mytenant.console.ves.volterra.io"
+  F5XC_API_TOKEN: "your-api-token"
+```
+
+### Deployment
+
+```yaml title="deployment.yaml"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: myapp:latest
+          envFrom:
+            - secretRef:
+                name: f5xc-credentials
+          env:
+            - name: F5XC_NAMESPACE
+              value: "production"
+```
+
+## Priority Order
+
+Environment variables override profile settings:
+
+1. **Environment Variables** (highest priority)
+2. **Active Profile**
+3. **Documentation Mode** (lowest priority)
+
+This allows you to:
+
+```bash
+# Use staging credentials even with production profile active
+F5XC_API_URL="https://staging.console.ves.volterra.io" \
+F5XC_API_TOKEN="staging-token" \
+npm run test
+```
+
+## TLS Configuration
+
+### Custom CA Bundle
+
+For environments with custom certificate authorities:
+
+```bash
+export F5XC_CA_BUNDLE="/etc/pki/tls/certs/custom-ca.crt"
+```
+
+### Insecure Mode (Staging Only)
+
+!!! danger "Warning"
+    Only use for staging/development environments!
+
+```bash
+export F5XC_TLS_INSECURE="true"
+```
+
+## Validation in Code
+
+Check if credentials come from environment:
+
+```typescript
+import { CredentialManager } from '@robinmordasiewicz/f5xc-auth';
+
+const cm = new CredentialManager();
+await cm.initialize();
+
+// getActiveProfile() returns null when using env vars
+if (!cm.getActiveProfile()) {
+  console.log('Using credentials from environment variables');
+} else {
+  console.log(`Using profile: ${cm.getActiveProfile()}`);
+}
+```
+
+## Troubleshooting
+
+### Variable Not Set
+
+```typescript
+if (!process.env.F5XC_API_URL) {
+  console.error('F5XC_API_URL is not set');
+  process.exit(1);
+}
+```
+
+### Variable Verification Script
+
+```typescript
+const required = ['F5XC_API_URL'];
+const authOptions = ['F5XC_API_TOKEN', 'F5XC_P12_BUNDLE', 'F5XC_CERT'];
+
+// Check required
+for (const v of required) {
+  if (!process.env[v]) {
+    console.error(`Missing required: ${v}`);
+    process.exit(1);
+  }
+}
+
+// Check at least one auth method
+const hasAuth = authOptions.some(v => process.env[v]);
+if (!hasAuth) {
+  console.error('No authentication configured');
+  console.error(`Set one of: ${authOptions.join(', ')}`);
+  process.exit(1);
+}
+```
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Variables not loaded | Ensure shell profile exports them |
+| Variables empty in Docker | Check docker-compose or K8s config |
+| CI variables not visible | Check secret/variable scope |
+| Token expired | Regenerate in F5 XC Console |

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,97 @@
+# Guides
+
+Practical guides for using `@robinmordasiewicz/f5xc-auth` in different scenarios.
+
+## Available Guides
+
+<div class="feature-grid" markdown>
+
+<div class="feature-card" markdown>
+
+### [Authentication Methods](authentication.md)
+
+Learn about the different ways to authenticate with F5 Distributed Cloud: API tokens, P12 certificates, and certificate/key pairs.
+
+</div>
+
+<div class="feature-card" markdown>
+
+### [Profile Management](profiles.md)
+
+Manage multiple F5 XC profiles for different tenants and environments. Learn to switch between profiles seamlessly.
+
+</div>
+
+<div class="feature-card" markdown>
+
+### [Environment Variables](environment.md)
+
+Configure authentication through environment variables for CI/CD pipelines and containerized deployments.
+
+</div>
+
+<div class="feature-card" markdown>
+
+### [Security Best Practices](security.md)
+
+Security considerations for credential storage, TLS configuration, and production deployments.
+
+</div>
+
+</div>
+
+## Common Scenarios
+
+### Local Development
+
+For local development, create a profile with your F5 XC credentials:
+
+```typescript
+import { getProfileManager } from '@robinmordasiewicz/f5xc-auth';
+
+const pm = getProfileManager();
+await pm.save({
+  name: 'dev',
+  apiUrl: 'https://mytenant.console.ves.volterra.io',
+  apiToken: 'your-token'
+});
+await pm.setActive('dev');
+```
+
+### CI/CD Pipelines
+
+Use environment variables in CI/CD pipelines:
+
+```yaml
+# GitHub Actions example
+env:
+  F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
+  F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
+```
+
+### Multiple Tenants
+
+Switch between different F5 XC tenants:
+
+```typescript
+const pm = getProfileManager();
+
+// List available profiles
+const profiles = await pm.list();
+
+// Switch to a different tenant
+await pm.setActive('production');
+```
+
+### Enterprise Environments
+
+For enterprise environments with custom CA certificates:
+
+```typescript
+await pm.save({
+  name: 'enterprise',
+  apiUrl: 'https://internal.tenant.com',
+  apiToken: 'your-token',
+  caBundle: '/etc/pki/tls/certs/enterprise-ca.crt'
+});
+```

--- a/docs/guides/profiles.md
+++ b/docs/guides/profiles.md
@@ -1,0 +1,289 @@
+# Profile Management
+
+This guide covers managing multiple F5 XC profiles for different tenants and environments.
+
+## Overview
+
+Profiles allow you to store and switch between different F5 XC configurations:
+
+- Multiple tenants
+- Different environments (dev, staging, production)
+- Different authentication methods
+- Different default namespaces
+
+## Creating Profiles
+
+### Using Code
+
+```typescript
+import { getProfileManager } from '@robinmordasiewicz/f5xc-auth';
+
+const pm = getProfileManager();
+
+// Create a production profile
+await pm.save({
+  name: 'production',
+  apiUrl: 'https://prod.console.ves.volterra.io',
+  apiToken: 'prod-token',
+  defaultNamespace: 'production'
+});
+
+// Create a staging profile
+await pm.save({
+  name: 'staging',
+  apiUrl: 'https://staging.console.ves.volterra.io',
+  apiToken: 'staging-token',
+  defaultNamespace: 'staging',
+  tlsInsecure: true  // For staging environments
+});
+```
+
+### Manual Creation
+
+Create a JSON file in `~/.config/f5xc/profiles/`:
+
+```json title="~/.config/f5xc/profiles/production.json"
+{
+  "name": "production",
+  "apiUrl": "https://mytenant.console.ves.volterra.io",
+  "apiToken": "your-api-token",
+  "defaultNamespace": "production"
+}
+```
+
+Or use YAML format:
+
+```yaml title="~/.config/f5xc/profiles/staging.yaml"
+name: staging
+api_url: https://staging.console.ves.volterra.io
+api_token: staging-token
+default_namespace: staging
+tls_insecure: true
+```
+
+!!! note "YAML Naming"
+    YAML files use `snake_case` keys which are automatically converted to `camelCase`.
+
+## Listing Profiles
+
+```typescript
+const profiles = await pm.list();
+
+profiles.forEach(profile => {
+  const masked = pm.maskProfile(profile);
+  console.log(`${profile.name}: ${profile.apiUrl}`);
+  console.log(`  Token: ${masked.apiToken}`);
+});
+```
+
+Output:
+```
+production: https://prod.console.ves.volterra.io
+  Token: ****abcd
+staging: https://staging.console.ves.volterra.io
+  Token: ****efgh
+```
+
+## Switching Profiles
+
+### Set Active Profile
+
+```typescript
+const result = await pm.setActive('production');
+if (result.success) {
+  console.log('Switched to production');
+}
+```
+
+### Get Current Profile
+
+```typescript
+// Get profile name
+const name = await pm.getActive();
+console.log(`Active profile: ${name}`);
+
+// Get full profile data
+const profile = await pm.getActiveProfile();
+if (profile) {
+  console.log(`Connected to: ${profile.apiUrl}`);
+}
+```
+
+## Updating Profiles
+
+To update a profile, save it with the same name:
+
+```typescript
+const profile = await pm.get('production');
+if (profile) {
+  // Update the namespace
+  profile.defaultNamespace = 'new-namespace';
+  await pm.save(profile);
+}
+```
+
+## Deleting Profiles
+
+```typescript
+const result = await pm.delete('old-profile');
+if (result.success) {
+  console.log('Profile deleted');
+} else {
+  console.error(result.message);
+}
+```
+
+!!! warning "Active Profile"
+    You cannot delete the currently active profile. Switch to another profile first.
+
+## Profile Validation
+
+Profiles are validated when saved:
+
+### Name Rules
+
+- Alphanumeric characters
+- Dashes (`-`) and underscores (`_`)
+- Maximum 64 characters
+
+```typescript
+// Valid names
+'production'
+'my-tenant-1'
+'staging_env'
+
+// Invalid names
+'my profile'      // Spaces not allowed
+'profile@1'       // Special characters not allowed
+```
+
+### URL Validation
+
+- Must be a valid HTTP or HTTPS URL
+- URLs are automatically normalized
+
+```typescript
+// These all normalize to the same URL:
+'mytenant'
+'mytenant.console.ves.volterra.io'
+'https://mytenant.console.ves.volterra.io'
+'https://mytenant.console.ves.volterra.io/'
+
+// Result: https://mytenant.console.ves.volterra.io/api
+```
+
+### Authentication Required
+
+At least one authentication method must be provided:
+
+```typescript
+// Valid - has apiToken
+{ name: 'p1', apiUrl: '...', apiToken: '...' }
+
+// Valid - has p12Bundle
+{ name: 'p2', apiUrl: '...', p12Bundle: '/path/to/cert.p12' }
+
+// Valid - has cert and key
+{ name: 'p3', apiUrl: '...', cert: '/path/to/cert.pem', key: '/path/to/key.pem' }
+
+// Invalid - no authentication
+{ name: 'p4', apiUrl: '...' }  // Error: Profile must have authentication
+```
+
+## Profile Security
+
+### File Permissions
+
+Profile files are created with secure permissions:
+
+- Profile files: `0600` (owner read/write only)
+- Config directory: `0700` (owner access only)
+
+### Token Masking
+
+When displaying profiles, tokens are automatically masked:
+
+```typescript
+const masked = pm.maskProfile(profile);
+console.log(masked.apiToken);  // ****abcd
+```
+
+## Common Patterns
+
+### Profile per Environment
+
+```typescript
+// Development
+await pm.save({
+  name: 'dev',
+  apiUrl: 'https://dev-tenant.console.ves.volterra.io',
+  apiToken: process.env.DEV_TOKEN!,
+  defaultNamespace: 'development'
+});
+
+// Staging
+await pm.save({
+  name: 'staging',
+  apiUrl: 'https://staging-tenant.console.ves.volterra.io',
+  apiToken: process.env.STAGING_TOKEN!,
+  defaultNamespace: 'staging',
+  tlsInsecure: true
+});
+
+// Production
+await pm.save({
+  name: 'prod',
+  apiUrl: 'https://prod-tenant.console.ves.volterra.io',
+  apiToken: process.env.PROD_TOKEN!,
+  defaultNamespace: 'production'
+});
+```
+
+### Profile per Tenant
+
+```typescript
+// Tenant A
+await pm.save({
+  name: 'tenant-a',
+  apiUrl: 'https://tenant-a.console.ves.volterra.io',
+  apiToken: 'token-a',
+  defaultNamespace: 'default'
+});
+
+// Tenant B
+await pm.save({
+  name: 'tenant-b',
+  apiUrl: 'https://tenant-b.console.ves.volterra.io',
+  apiToken: 'token-b',
+  defaultNamespace: 'default'
+});
+```
+
+### Profile Selection Script
+
+```typescript
+import { getProfileManager, CredentialManager, createHttpClient } from '@robinmordasiewicz/f5xc-auth';
+
+async function useProfile(name: string) {
+  const pm = getProfileManager();
+
+  // Check profile exists
+  if (!await pm.exists(name)) {
+    throw new Error(`Profile '${name}' not found`);
+  }
+
+  // Set active
+  await pm.setActive(name);
+
+  // Initialize new credentials
+  const cm = new CredentialManager();
+  await cm.initialize();
+
+  // Create client
+  return createHttpClient(cm);
+}
+
+// Usage
+const client = await useProfile('production');
+const response = await client.get('/web/namespaces');
+```

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1,0 +1,292 @@
+# Security Best Practices
+
+This guide covers security considerations when using `f5xc-auth`.
+
+## Credential Storage
+
+### Profile Files
+
+Profile files are stored with secure permissions:
+
+- **Profile files**: `0600` (owner read/write only)
+- **Config directory**: `0700` (owner access only)
+
+```bash
+ls -la ~/.config/f5xc/profiles/
+# -rw------- 1 user user 245 Jan 1 12:00 production.json
+```
+
+### Never Commit Credentials
+
+Add to your `.gitignore`:
+
+```gitignore
+# F5XC credentials
+.config/f5xc/
+*.p12
+*.pem
+
+# Environment files
+.env
+.env.local
+.env.*.local
+```
+
+### Use Environment Variables in CI/CD
+
+Never hardcode credentials in scripts or configs:
+
+```yaml
+# Good - use secrets
+env:
+  F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
+
+# Bad - hardcoded
+env:
+  F5XC_API_TOKEN: "actual-token-value"  # Never do this!
+```
+
+## Token Management
+
+### Token Best Practices
+
+1. **Set expiration dates** - Don't use permanent tokens
+2. **Rotate regularly** - Regenerate tokens periodically
+3. **Use minimal scope** - Request only needed permissions
+4. **One token per environment** - Don't share tokens across environments
+
+### Token Rotation
+
+```typescript
+import { getProfileManager } from '@robinmordasiewicz/f5xc-auth';
+
+async function rotateToken(profileName: string, newToken: string) {
+  const pm = getProfileManager();
+  const profile = await pm.get(profileName);
+
+  if (profile) {
+    profile.apiToken = newToken;
+    await pm.save(profile);
+    console.log(`Token rotated for profile: ${profileName}`);
+  }
+}
+```
+
+### Token Masking
+
+The library automatically masks tokens when displaying:
+
+```typescript
+const masked = pm.maskProfile(profile);
+console.log(masked.apiToken);  // ****abcd (last 4 chars only)
+```
+
+## TLS Security
+
+### Custom CA Bundles
+
+For enterprise environments with internal CAs:
+
+```json
+{
+  "name": "enterprise",
+  "apiUrl": "https://internal.tenant.com",
+  "apiToken": "...",
+  "caBundle": "/etc/pki/tls/certs/enterprise-ca.crt"
+}
+```
+
+Or via environment:
+
+```bash
+export F5XC_CA_BUNDLE="/etc/pki/tls/certs/enterprise-ca.crt"
+```
+
+### Insecure Mode Warnings
+
+!!! danger "Never use in production"
+    TLS insecure mode disables certificate verification, making connections vulnerable to MITM attacks.
+
+When insecure mode is enabled, the library outputs a warning:
+
+```
+⚠️  WARNING: TLS certificate verification is DISABLED
+   URL: https://staging.tenant.com
+   This should ONLY be used for staging/development environments!
+   Consider using F5XC_CA_BUNDLE for a more secure solution.
+```
+
+### When to Use Insecure Mode
+
+Only in these specific scenarios:
+
+- Local development with self-signed certificates
+- Staging environments with temporary certificates
+- Testing and CI pipelines with mock servers
+
+### Better Alternatives
+
+Instead of insecure mode, consider:
+
+1. **Custom CA bundle** - Add your CA to `F5XC_CA_BUNDLE`
+2. **System trust store** - Add CA to system certificates
+3. **Proper certificates** - Request valid certificates for staging
+
+## Certificate Security
+
+### P12 Certificate Handling
+
+```typescript
+// P12 files are read into memory, not stored in profiles
+// The path is stored, file is read at runtime
+{
+  "p12Bundle": "/secure/path/certificate.p12"
+}
+```
+
+### Certificate File Permissions
+
+Ensure certificate files have restricted permissions:
+
+```bash
+chmod 600 /path/to/certificate.p12
+chmod 600 /path/to/cert.pem
+chmod 600 /path/to/key.pem
+```
+
+### Certificate Storage Locations
+
+| Environment | Recommended Location |
+|-------------|---------------------|
+| Linux | `/etc/ssl/private/` or `~/.ssl/` |
+| macOS | `~/Library/Security/` or `~/.ssl/` |
+| Container | `/run/secrets/` (Docker secrets) |
+
+## Error Handling
+
+### Don't Expose Credentials in Errors
+
+```typescript
+try {
+  await client.get('/api/endpoint');
+} catch (error) {
+  // Good - don't log credentials
+  console.error('API request failed:', error.message);
+
+  // Bad - might expose sensitive data
+  console.error('Full error:', error);  // Could contain auth headers
+}
+```
+
+### Secure Logging
+
+```typescript
+import { logger } from '@robinmordasiewicz/f5xc-auth';
+
+// The library's logger already masks sensitive data
+logger.info('Credentials loaded', {
+  mode: cm.getAuthMode(),
+  tenant: cm.getTenant(),
+  // Token is NOT logged
+});
+```
+
+## Production Checklist
+
+### Before Deployment
+
+- [ ] No hardcoded credentials in code
+- [ ] No credentials in version control
+- [ ] TLS insecure mode disabled
+- [ ] Token expiration set appropriately
+- [ ] Certificate permissions restricted
+- [ ] Environment variables use secrets management
+- [ ] Custom CA bundle configured (if needed)
+
+### Runtime Security
+
+- [ ] Credentials loaded from secure source
+- [ ] Errors don't expose sensitive data
+- [ ] Logging doesn't include credentials
+- [ ] Token rotation process documented
+- [ ] Incident response plan for credential leak
+
+## Secrets Management Integration
+
+### HashiCorp Vault
+
+```typescript
+import Vault from 'node-vault';
+
+const vault = Vault({ endpoint: 'https://vault.example.com' });
+
+async function loadFromVault() {
+  const secret = await vault.read('secret/data/f5xc');
+
+  process.env.F5XC_API_URL = secret.data.data.api_url;
+  process.env.F5XC_API_TOKEN = secret.data.data.api_token;
+
+  // Now initialize f5xc-auth
+  const cm = new CredentialManager();
+  await cm.initialize();
+  return cm;
+}
+```
+
+### AWS Secrets Manager
+
+```typescript
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+
+const client = new SecretsManagerClient({ region: 'us-east-1' });
+
+async function loadFromAWS() {
+  const response = await client.send(
+    new GetSecretValueCommand({ SecretId: 'f5xc/credentials' })
+  );
+
+  const secret = JSON.parse(response.SecretString!);
+
+  process.env.F5XC_API_URL = secret.api_url;
+  process.env.F5XC_API_TOKEN = secret.api_token;
+
+  const cm = new CredentialManager();
+  await cm.initialize();
+  return cm;
+}
+```
+
+### Kubernetes Secrets
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: f5xc-credentials
+  annotations:
+    # For external secrets operator
+    external-secrets.io/refresh-interval: "1h"
+type: Opaque
+stringData:
+  F5XC_API_URL: "https://tenant.console.ves.volterra.io"
+  F5XC_API_TOKEN: "your-api-token"
+```
+
+## Incident Response
+
+### If Credentials Are Leaked
+
+1. **Immediately rotate** - Generate new token in F5 XC Console
+2. **Update all references** - Update profiles and environment variables
+3. **Audit access** - Review F5 XC audit logs for unauthorized access
+4. **Identify source** - Determine how leak occurred
+5. **Prevent recurrence** - Implement controls to prevent future leaks
+
+### Audit Logging
+
+Monitor F5 XC audit logs for:
+
+- Unusual API access patterns
+- Access from unexpected IP addresses
+- Failed authentication attempts
+- High-frequency API calls

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,115 @@
+# f5xc-auth
+
+<div class="hero" markdown>
+
+# f5xc-auth
+
+Shared authentication library for F5 Distributed Cloud MCP servers.
+XDG-compliant profile management and credential handling.
+
+<div class="hero-badges">
+  <a href="https://www.npmjs.com/package/@robinmordasiewicz/f5xc-auth">
+    <img src="https://img.shields.io/npm/v/@robinmordasiewicz/f5xc-auth?style=flat-square&color=4f73ff" alt="npm version">
+  </a>
+  <a href="https://github.com/robinmordasiewicz/f5xc-auth/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/robinmordasiewicz/f5xc-auth?style=flat-square" alt="license">
+  </a>
+  <a href="https://github.com/robinmordasiewicz/f5xc-auth">
+    <img src="https://img.shields.io/github/stars/robinmordasiewicz/f5xc-auth?style=flat-square" alt="GitHub stars">
+  </a>
+</div>
+
+</div>
+
+## Overview
+
+`@robinmordasiewicz/f5xc-auth` provides a unified authentication layer for F5 Distributed Cloud (F5 XC) applications. It handles credential management, profile storage, and HTTP client configuration following XDG Base Directory specifications.
+
+## Features
+
+<div class="feature-grid" markdown>
+
+<div class="feature-card" markdown>
+
+### :material-folder-key: XDG-Compliant Storage
+
+Profiles stored in `~/.config/f5xc/profiles/` following XDG Base Directory specification for cross-platform compatibility.
+
+</div>
+
+<div class="feature-card" markdown>
+
+### :material-key-chain: Multiple Auth Methods
+
+Support for API tokens, P12 certificate bundles, and certificate/key pairs for flexible authentication options.
+
+</div>
+
+<div class="feature-card" markdown>
+
+### :material-cog: Environment Variables
+
+Override profile settings with environment variables for CI/CD pipelines and containerized deployments.
+
+</div>
+
+<div class="feature-card" markdown>
+
+### :material-link: URL Normalization
+
+Automatically handles various F5 XC tenant URL formats, normalizing them for consistent API access.
+
+</div>
+
+<div class="feature-card" markdown>
+
+### :material-shield-lock: TLS Configuration
+
+Custom CA bundles for enterprise environments and insecure mode for staging/development.
+
+</div>
+
+<div class="feature-card" markdown>
+
+### :material-api: HTTP Client
+
+Pre-configured Axios HTTP client with automatic authentication header injection and retry logic.
+
+</div>
+
+</div>
+
+## Quick Install
+
+```bash
+npm install @robinmordasiewicz/f5xc-auth
+```
+
+## Basic Usage
+
+```typescript
+import { CredentialManager } from '@robinmordasiewicz/f5xc-auth';
+
+const credentialManager = new CredentialManager();
+await credentialManager.initialize();
+
+if (credentialManager.isAuthenticated()) {
+  console.log(`Authenticated as: ${credentialManager.getTenant()}`);
+  console.log(`API URL: ${credentialManager.getApiUrl()}`);
+}
+```
+
+## Requirements
+
+- **Node.js**: 18 or later
+- **F5 Distributed Cloud**: Valid tenant credentials
+
+## Getting Help
+
+- [Getting Started Guide](getting-started/index.md) - Installation and initial setup
+- [API Reference](api/index.md) - Complete API documentation
+- [GitHub Issues](https://github.com/robinmordasiewicz/f5xc-auth/issues) - Report bugs or request features
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](https://github.com/robinmordasiewicz/f5xc-auth/blob/main/LICENSE) file for details.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <meta name="author" content="Robin Mordasiewicz">
+  <meta name="keywords" content="f5xc, f5, distributed cloud, authentication, mcp, model context protocol">
+{% endblock %}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,566 @@
+/* ============================================
+   F5XC-AUTH Documentation Custom Styles
+   Based on f5xc-xcsh theme with F5 branding
+   ============================================ */
+
+/* -----------------------------------------
+   CSS Custom Properties - Light Mode
+   ----------------------------------------- */
+:root {
+  /* F5 Brand Colors */
+  --md-primary-fg-color: #4f73ff;
+  --md-primary-fg-color--light: #6b8aff;
+  --md-primary-fg-color--dark: #3d5dcc;
+  --md-accent-fg-color: #4f73ff;
+
+  /* Text Colors */
+  --md-default-fg-color: #0f1e57;
+  --md-default-fg-color--light: #4a5568;
+  --md-default-fg-color--lighter: #718096;
+  --md-default-fg-color--lightest: #a0aec0;
+
+  /* Background Colors */
+  --md-default-bg-color: #ffffff;
+  --md-default-bg-color--light: #f7fafc;
+  --md-default-bg-color--lighter: #edf2f7;
+  --md-default-bg-color--lightest: #e2e8f0;
+
+  /* Code Block Colors */
+  --md-code-bg-color: #f4f6f8;
+  --md-code-fg-color: #0f1e57;
+  --md-code-hl-color: rgba(79, 115, 255, 0.1);
+
+  /* Typography */
+  --md-text-font: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --md-code-font: "JetBrains Mono", "Fira Code", "Consolas", monospace;
+
+  /* Sizing */
+  --md-sidebar-width: 16rem;
+  --md-toc-width: 11rem;
+}
+
+/* -----------------------------------------
+   CSS Custom Properties - Dark Mode
+   GitHub Dark Theme
+   ----------------------------------------- */
+[data-md-color-scheme="slate"] {
+  /* Background */
+  --md-default-bg-color: #0d1117;
+  --md-default-bg-color--light: #161b22;
+  --md-default-bg-color--lighter: #21262d;
+  --md-default-bg-color--lightest: #30363d;
+
+  /* Text */
+  --md-default-fg-color: #e6edf3;
+  --md-default-fg-color--light: #8b949e;
+  --md-default-fg-color--lighter: #6e7681;
+  --md-default-fg-color--lightest: #484f58;
+
+  /* Primary/Accent */
+  --md-primary-fg-color: #58a6ff;
+  --md-primary-fg-color--light: #79b8ff;
+  --md-primary-fg-color--dark: #388bfd;
+  --md-accent-fg-color: #58a6ff;
+
+  /* Code */
+  --md-code-bg-color: #161b22;
+  --md-code-fg-color: #e6edf3;
+  --md-code-hl-color: rgba(88, 166, 255, 0.15);
+
+  /* Footer */
+  --md-footer-bg-color: #0d1117;
+  --md-footer-bg-color--dark: #010409;
+}
+
+/* -----------------------------------------
+   Typography Base
+   ----------------------------------------- */
+html {
+  font-size: 14px;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--md-text-font);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* -----------------------------------------
+   Headers
+   ----------------------------------------- */
+.md-content h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--md-default-bg-color--lightest);
+}
+
+.md-content h2 {
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.md-content h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.md-content h4,
+.md-content h5,
+.md-content h6 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+/* -----------------------------------------
+   Navigation
+   ----------------------------------------- */
+.md-nav__link {
+  font-size: 0.75rem;
+  padding: 0.4rem 0.75rem;
+}
+
+.md-nav__item--active > .md-nav__link {
+  font-weight: 600;
+  color: var(--md-primary-fg-color);
+}
+
+.md-tabs__link {
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+/* Sidebar */
+.md-sidebar--primary {
+  width: var(--md-sidebar-width);
+}
+
+.md-sidebar--secondary {
+  width: var(--md-toc-width);
+}
+
+/* -----------------------------------------
+   Code Blocks
+   ----------------------------------------- */
+.md-typeset code {
+  font-family: var(--md-code-font);
+  font-size: 0.75rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  background-color: var(--md-code-bg-color);
+}
+
+.md-typeset pre {
+  border-radius: 6px;
+  margin: 1rem 0;
+}
+
+.md-typeset pre > code {
+  font-size: 0.75rem;
+  line-height: 1.5;
+  padding: 0.75rem 1rem;
+}
+
+/* Code copy button */
+.md-clipboard {
+  color: var(--md-default-fg-color--lighter);
+}
+
+.md-clipboard:hover {
+  color: var(--md-primary-fg-color);
+}
+
+/* Syntax highlighting adjustments */
+.highlight .linenos {
+  color: var(--md-default-fg-color--lightest);
+  padding-right: 1rem;
+  border-right: 1px solid var(--md-default-bg-color--lightest);
+  margin-right: 1rem;
+}
+
+/* -----------------------------------------
+   Tables
+   ----------------------------------------- */
+.md-typeset table:not([class]) {
+  font-size: 0.8rem;
+  border-collapse: collapse;
+  margin: 1rem 0;
+  display: table;
+  width: 100%;
+}
+
+.md-typeset table:not([class]) th {
+  background-color: var(--md-default-bg-color--light);
+  font-weight: 600;
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--md-default-bg-color--lightest);
+}
+
+.md-typeset table:not([class]) td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--md-default-bg-color--lightest);
+  vertical-align: top;
+}
+
+.md-typeset table:not([class]) tr:hover td {
+  background-color: var(--md-code-hl-color);
+}
+
+/* -----------------------------------------
+   Admonitions
+   ----------------------------------------- */
+.md-typeset .admonition,
+.md-typeset details {
+  font-size: 0.8rem;
+  border-radius: 6px;
+  margin: 1rem 0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.md-typeset .admonition-title,
+.md-typeset summary {
+  font-weight: 600;
+  padding: 0.5rem 0.75rem;
+}
+
+/* Custom admonition colors */
+.md-typeset .admonition.note,
+.md-typeset details.note {
+  border-color: var(--md-primary-fg-color);
+}
+
+.md-typeset .admonition.tip,
+.md-typeset details.tip {
+  border-color: #10b981;
+}
+
+.md-typeset .admonition.warning,
+.md-typeset details.warning {
+  border-color: #f59e0b;
+}
+
+.md-typeset .admonition.danger,
+.md-typeset details.danger {
+  border-color: #ef4444;
+}
+
+/* -----------------------------------------
+   Hero Section (Home Page)
+   ----------------------------------------- */
+.md-typeset .hero {
+  text-align: center;
+  padding: 3rem 1rem;
+  margin: -1rem -1rem 2rem -1rem;
+  background: linear-gradient(135deg, var(--md-primary-fg-color) 0%, var(--md-primary-fg-color--dark) 100%);
+  color: white;
+  border-radius: 0 0 12px 12px;
+}
+
+.md-typeset .hero h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  border: none;
+  padding: 0;
+  color: white;
+}
+
+.md-typeset .hero p {
+  font-size: 1.1rem;
+  opacity: 0.9;
+  max-width: 600px;
+  margin: 0 auto 1.5rem auto;
+}
+
+.md-typeset .hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.md-typeset .hero-badges img {
+  height: 24px;
+}
+
+/* -----------------------------------------
+   Feature Cards
+   ----------------------------------------- */
+.md-typeset .feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.md-typeset .feature-card {
+  padding: 1.25rem;
+  background: var(--md-default-bg-color--light);
+  border-radius: 8px;
+  border: 1px solid var(--md-default-bg-color--lightest);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.md-typeset .feature-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+}
+
+.md-typeset .feature-card h3 {
+  font-size: 1rem;
+  margin: 0 0 0.5rem 0;
+  color: var(--md-primary-fg-color);
+}
+
+.md-typeset .feature-card p {
+  font-size: 0.85rem;
+  margin: 0;
+  color: var(--md-default-fg-color--light);
+}
+
+/* -----------------------------------------
+   Badges
+   ----------------------------------------- */
+.md-typeset .badge {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  border-radius: 4px;
+  letter-spacing: 0.025em;
+}
+
+.md-typeset .badge-primary {
+  background-color: var(--md-primary-fg-color);
+  color: white;
+}
+
+.md-typeset .badge-success {
+  background-color: #10b981;
+  color: white;
+}
+
+.md-typeset .badge-warning {
+  background-color: #f59e0b;
+  color: white;
+}
+
+.md-typeset .badge-danger {
+  background-color: #ef4444;
+  color: white;
+}
+
+/* -----------------------------------------
+   Search
+   ----------------------------------------- */
+.md-search__input {
+  font-size: 0.8rem;
+  border-radius: 6px;
+}
+
+.md-search-result__meta {
+  font-size: 0.7rem;
+}
+
+.md-search-result__title {
+  font-size: 0.85rem;
+}
+
+/* -----------------------------------------
+   Footer
+   ----------------------------------------- */
+.md-footer {
+  font-size: 0.75rem;
+}
+
+.md-footer-meta {
+  padding: 0.75rem 0;
+}
+
+/* Hide "Made with Material for MkDocs" */
+.md-footer-meta__inner.md-grid {
+  display: flex;
+  justify-content: center;
+}
+
+/* -----------------------------------------
+   Scrollbar (WebKit browsers)
+   ----------------------------------------- */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--md-default-bg-color--light);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--md-default-fg-color--lightest);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--md-default-fg-color--lighter);
+}
+
+/* -----------------------------------------
+   Responsive Adjustments
+   ----------------------------------------- */
+@media screen and (max-width: 76.1875em) {
+  .md-sidebar--primary {
+    width: 100%;
+  }
+}
+
+@media screen and (max-width: 60em) {
+  .md-typeset .hero h1 {
+    font-size: 1.75rem;
+  }
+
+  .md-typeset .feature-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* -----------------------------------------
+   Print Styles
+   ----------------------------------------- */
+@media print {
+  .md-sidebar,
+  .md-header,
+  .md-footer,
+  .md-tabs {
+    display: none !important;
+  }
+
+  .md-content {
+    margin: 0 !important;
+    max-width: 100% !important;
+  }
+
+  .md-typeset .hero {
+    background: none !important;
+    color: var(--md-default-fg-color) !important;
+    padding: 1rem 0 !important;
+  }
+}
+
+/* -----------------------------------------
+   API Reference Specific Styles
+   ----------------------------------------- */
+.md-typeset .api-method {
+  display: inline-block;
+  padding: 0.15rem 0.4rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  font-family: var(--md-code-font);
+  text-transform: uppercase;
+  border-radius: 4px;
+  margin-right: 0.5rem;
+}
+
+.md-typeset .api-method-get {
+  background-color: #10b981;
+  color: white;
+}
+
+.md-typeset .api-method-post {
+  background-color: #3b82f6;
+  color: white;
+}
+
+.md-typeset .api-method-put {
+  background-color: #f59e0b;
+  color: white;
+}
+
+.md-typeset .api-method-delete {
+  background-color: #ef4444;
+  color: white;
+}
+
+/* Parameter table styling */
+.md-typeset .param-table {
+  font-size: 0.8rem;
+}
+
+.md-typeset .param-table code {
+  font-size: 0.7rem;
+}
+
+.md-typeset .param-required {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+.md-typeset .param-optional {
+  color: var(--md-default-fg-color--lighter);
+}
+
+/* Type annotations */
+.md-typeset .type-annotation {
+  color: var(--md-primary-fg-color);
+  font-family: var(--md-code-font);
+  font-size: 0.75rem;
+}
+
+/* -----------------------------------------
+   Tabs Content
+   ----------------------------------------- */
+.md-typeset .tabbed-set {
+  margin: 1rem 0;
+}
+
+.md-typeset .tabbed-labels > label {
+  font-size: 0.8rem;
+  padding: 0.5rem 1rem;
+}
+
+/* -----------------------------------------
+   Installation Command Box
+   ----------------------------------------- */
+.md-typeset .install-command {
+  background: var(--md-code-bg-color);
+  border: 1px solid var(--md-default-bg-color--lightest);
+  border-radius: 6px;
+  padding: 1rem;
+  margin: 1rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.md-typeset .install-command code {
+  flex: 1;
+  background: none;
+  padding: 0;
+  font-size: 0.85rem;
+}
+
+.md-typeset .install-command .copy-btn {
+  padding: 0.25rem 0.5rem;
+  background: var(--md-primary-fg-color);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.md-typeset .install-command .copy-btn:hover {
+  background: var(--md-primary-fg-color--dark);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,104 @@
+site_name: f5xc-auth Documentation
+site_description: Shared authentication library for F5 Distributed Cloud MCP servers
+site_url: https://robinmordasiewicz.github.io/f5xc-auth/
+repo_name: robinmordasiewicz/f5xc-auth
+repo_url: https://github.com/robinmordasiewicz/f5xc-auth
+
+theme:
+  name: material
+  custom_dir: docs/overrides
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  features:
+    - navigation.tabs
+    - navigation.indexes
+    - navigation.path
+    - navigation.top
+    - navigation.footer
+    - navigation.instant
+    - navigation.tracking
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - toc.follow
+    - header.autohide
+  icon:
+    repo: fontawesome/brands/github
+    logo: material/key-chain
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.mark
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - admonition
+  - tables
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+      toc_depth: 3
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/robinmordasiewicz/f5xc-auth
+    - icon: fontawesome/brands/npm
+      link: https://www.npmjs.com/package/@robinmordasiewicz/f5xc-auth
+  generator: false
+
+extra_css:
+  - stylesheets/extra.css
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - getting-started/index.md
+      - Installation: getting-started/installation.md
+      - Quick Start: getting-started/quickstart.md
+      - Configuration: getting-started/configuration.md
+  - API Reference:
+      - api/index.md
+      - CredentialManager: api/credential-manager.md
+      - ProfileManager: api/profile-manager.md
+      - HTTP Client: api/http-client.md
+  - Guides:
+      - guides/index.md
+      - Authentication Methods: guides/authentication.md
+      - Profile Management: guides/profiles.md
+      - Environment Variables: guides/environment.md
+      - Security: guides/security.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+mkdocs>=1.6.0
+mkdocs-material>=9.7.0
+mkdocs-minify-plugin>=0.8.0
+pymdown-extensions>=10.14


### PR DESCRIPTION
## Summary

Add comprehensive documentation site using Material for MkDocs with GitHub Actions workflow for automatic publishing.

## Changes

### New Files
- `mkdocs.yml` - MkDocs configuration with Material theme
- `requirements-docs.txt` - Python dependencies
- `.github/workflows/docs.yml` - GitHub Actions workflow for GitHub Pages deployment
- `docs/` - 16 documentation files including API reference and guides

### Modified Files
- `.gitignore` - Added `site/` directory

## Documentation Structure
- **Home**: Landing page with hero section and feature overview
- **Getting Started**: Installation, quick start, configuration
- **API Reference**: CredentialManager, ProfileManager, HttpClient
- **Guides**: Authentication, profiles, environment variables, security

## Features
- Light/dark mode with F5 branding
- Code syntax highlighting with copy button
- Navigation tabs and instant loading
- Search with suggestions
- Responsive design

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)