### PR TITLE
ci: convert docs workflow to deploy to gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,9 +14,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
@@ -26,7 +24,7 @@ env:
   PYTHON_VERSION: '3.13'
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,18 +51,10 @@ jobs:
       - name: Build documentation
         run: mkdocs build --strict
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: site/
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          force_orphan: true


### PR DESCRIPTION
## Summary

Convert the Documentation workflow from artifact-based GitHub Pages deployment to branch-based deployment targeting the `gh-pages` branch.

## Changes

### Workflow Modifications
- **Job structure**: Combined `build` and `deploy` into single `deploy` job
- **Permissions**: Changed from `pages: write` and `id-token: write` to `contents: write`
- **Deployment method**: Replaced artifact-based actions with `peaceiris/actions-gh-pages@v4`
- **Configuration**: Deploy to `gh-pages` branch as orphan for clean history

### Deployment Settings
- `publish_dir: ./site` - Built documentation directory
- `publish_branch: gh-pages` - Target deployment branch
- `force_orphan: true` - Clean orphan branch with no history

## Post-Merge Action Required

After merging, update GitHub Pages settings:
1. Navigate to Settings → Pages
2. Change Source from "GitHub Actions" to "Deploy from a branch"
3. Select branch: `gh-pages` and directory: `/ (root)`

The workflow will automatically create the `gh-pages` branch on first run.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)