### PR TITLE
chore: update to MIT license with 2026 copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Robin Mordasiewicz
+Copyright (c) 2026 Robin Mordasiewicz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/auth/__tests__/url-normalization.test.ts
+++ b/src/auth/__tests__/url-normalization.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * URL Normalization Unit Tests
  *

--- a/src/auth/credential-manager.ts
+++ b/src/auth/credential-manager.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Credential Manager for F5 Distributed Cloud API
  *

--- a/src/auth/http-client.ts
+++ b/src/auth/http-client.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Authenticated HTTP Client for F5 Distributed Cloud API
  *

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Auth module exports
  */

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Config module exports
  */

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * XDG Base Directory compliant paths for F5 XC configuration
  * See: https://specifications.freedesktop.org/basedir/latest/

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * @robinmordasiewicz/f5xc-auth
  *

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Profile module exports
  */

--- a/src/profile/manager.ts
+++ b/src/profile/manager.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * ProfileManager - XDG-compliant profile storage and management
  *

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Profile types for F5 XC authentication and configuration
  *

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Error classes for f5xc-auth
  *

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Utils module exports
  */

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Logging utilities for f5xc-auth
  *


### PR DESCRIPTION
## Summary
- Update LICENSE file with 2026 copyright year
- Add copyright headers to all TypeScript source files
- Ensure MIT license compliance across the codebase

## Test plan
- Verify all files contain correct copyright headers
- Confirm LICENSE file has been updated
- Run CI/CD pipeline to ensure no regressions

Closes #10