### PR TITLE
chore(auth): test automated release with auth scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/src/auth/credential-manager.ts
+++ b/src/auth/credential-manager.ts
@@ -9,6 +9,9 @@
  * - Execution mode: API token or P12/Certificate authentication
  *
  * Uses XDG-compliant profile storage at ~/.config/f5xc/
+ *
+ * @module credential-manager
+ * @since 1.0.0
  */
 
 import { readFileSync } from "fs";


### PR DESCRIPTION
## 🧪 Testing Automated Release with Auth Scope

This PR tests the complete automated release pipeline with the new auth scope rules.

## Changes

### 1. Auth Module Enhancement
- ✅ Added JSDoc `@module` and `@since` tags to credential-manager
- ✅ Improves TypeScript documentation and type system integration

### 2. Workflow Fix
- ✅ Changed `persist-credentials: false` → `persist-credentials: true`
- ✅ Allows semantic-release to push version updates back to main
- ✅ Required for automated version commits

## Expected Behavior

When this PR merges:

1. ✅ **CI checks pass** (build, test, typecheck)
2. ✅ **Release workflow triggers** on push to main
3. ✅ **Commit analysis** detects `chore(auth)` scope
4. ✅ **Patch version bump** 1.0.1 → 1.0.2 (auth scope rule)
5. ✅ **CHANGELOG.md updated** with auth changes
6. ✅ **GitHub release created** with v1.0.2
7. ✅ **npm package published** @robinmordasiewicz/f5xc-auth@1.0.2
8. ✅ **Version commit pushed** back to main

## Testing the Rule

This commit uses `chore(auth):` type which would normally **NOT** trigger a release.

However, with our new rules:
- `chore` commits → ❌ No release
- `chore(auth)` commits → ✅ **Patch release**

This validates that:
1. Auth scope override works correctly
2. Workflow credentials are configured properly
3. Repository ruleset allows workflow commits
4. Full automation pipeline functions end-to-end

## Verification Steps

After merge, verify:
- [ ] Release workflow completes successfully
- [ ] Version bumped to 1.0.2
- [ ] CHANGELOG.md updated with this change
- [ ] GitHub release exists: https://github.com/robinmordasiewicz/f5xc-auth/releases/tag/v1.0.2
- [ ] npm package published: https://www.npmjs.com/package/@robinmordasiewicz/f5xc-auth/v/1.0.2
- [ ] Version commit appears in main branch

---

🤖 Testing automated release pipeline with auth scope rules