### PR TITLE
docs: update README and add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to f5xc-auth
+
+## Automated Release Process
+
+This project uses **semantic-release** for automated versioning and publishing. Commits to the `main` branch automatically trigger version bumps and npm releases based on commit message format.
+
+## Commit Message Format
+
+Use **Conventional Commits** format for all commits:
+
+| Type | Description | Version Bump |
+|------|-------------|--------------|
+| `feat:` | New feature | Minor (0.x.0) |
+| `fix:` | Bug fix | Patch (0.0.x) |
+| `docs:` | Documentation only | None |
+| `test:` | Tests only | None |
+| `chore:` | Build/tooling changes | None |
+
+**Examples:**
+```bash
+feat: add P12 certificate authentication
+fix: resolve profile loading race condition
+docs: update authentication guide
+test: add integration tests for profile rotation
+chore: update dependencies
+```
+
+## Breaking Changes
+
+To trigger a **major version** bump (x.0.0), add `BREAKING CHANGE:` in the commit footer:
+
+```bash
+feat: redesign profile API
+
+BREAKING CHANGE: ProfileManager.load() now returns Promise<Profile> instead of Profile
+```
+
+## Development Workflow
+
+1. **Clone and install**:
+   ```bash
+   git clone https://github.com/robinmordasiewicz/f5xc-auth.git
+   cd f5xc-auth
+   npm install
+   ```
+
+2. **Make changes**: Follow existing code patterns and TypeScript best practices
+
+3. **Run tests**: Ensure all tests pass before committing
+   ```bash
+   npm test              # Run all tests
+   npm run test:unit     # Unit tests only
+   npm run test:integration  # Integration tests
+   npm run test:coverage # Generate coverage report
+   ```
+
+4. **Commit with conventional format**: Your commit message determines the release version
+
+## Full Documentation
+
+For comprehensive guidelines including:
+- Detailed testing strategies
+- Code style standards
+- Security considerations
+- Architecture patterns
+
+See **[docs/contributing.md](./docs/contributing.md)** (298 lines)

--- a/README.md
+++ b/README.md
@@ -1,131 +1,56 @@
-# F5 Distributed Cloud Monorepo
+# f5xc-auth
 
-Unified monorepo combining F5 Distributed Cloud authentication, Terraform provider, and API MCP server.
+[![npm version](https://img.shields.io/npm/v/@robinmordasiewicz/f5xc-auth)](https://www.npmjs.com/package/@robinmordasiewicz/f5xc-auth)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## Packages
+Authentication library for F5 Distributed Cloud with XDG-compliant profile management.
 
-This monorepo contains three main packages:
-
-### 1. [@robinmordasiewicz/f5xc-auth](./packages/f5xc-auth/)
-
-Shared authentication library for F5 Distributed Cloud MCP servers. Provides XDG-compliant profile management and credential handling.
-
-- **NPM**: `@robinmordasiewicz/f5xc-auth`
-- **Features**: API token, P12 certificate, cert/key authentication, profile management, URL normalization
-- **Directory**: `packages/f5xc-auth/`
-
-### 2. [@robinmordasiewicz/f5xc-api-mcp](./packages/f5xc-api-mcp/)
-
-MCP (Model Context Protocol) server that exposes F5 Distributed Cloud APIs to AI assistants. Enables natural language interaction with F5XC infrastructure through Claude, VS Code, and other MCP-compatible tools.
-
-- **NPM**: `@robinmordasiewicz/f5xc-api-mcp`
-- **Features**: 1500+ API tools, domain-based documentation, dual-mode operation (docs + execution), curl examples
-- **Directory**: `packages/f5xc-api-mcp/`
-
-### 3. [Terraform Provider for F5 Distributed Cloud](./packages/terraform-provider/)
-
-Community Terraform provider for F5 Distributed Cloud (version 3.0.0 - clean break release).
-
-- **Registry**: `robinmordasiewicz/f5xc`
-- **Features**: API v2 based, 98+ resources available, import support, pre-release clean break
-- **Directory**: `packages/terraform-provider/`
-- **Language**: Go
-
-## Getting Started
-
-### Prerequisites
-
-- Node.js >= 18.0.0
-- npm >= 7.0.0 (for workspace support)
-- Go >= 1.22 (for Terraform provider development)
-
-### Installation
-
-Clone the repository:
+## Installation
 
 ```bash
-git clone https://github.com/robinmordasiewicz/f5xc.git
-cd f5xc
+npm install @robinmordasiewicz/f5xc-auth
 ```
 
-Install dependencies for all packages:
+## Quick Start
 
-```bash
-npm install
+```typescript
+import { HttpClient, ProfileManager } from '@robinmordasiewicz/f5xc-auth';
+
+// Load profile
+const profile = await ProfileManager.load('my-profile');
+
+// Create authenticated HTTP client
+const client = await HttpClient.create(profile);
+
+// Make API call
+const response = await client.get('/api/v1/namespace');
 ```
 
-### Development
+## Features
 
-Run tests across all packages:
-
-```bash
-npm test
-```
-
-Build all packages:
-
-```bash
-npm run build
-```
-
-Lint all packages:
-
-```bash
-npm run lint
-```
-
-### Working with Individual Packages
-
-Change into a package directory and work as normal:
-
-```bash
-cd packages/f5xc-auth
-npm install
-npm run build
-npm test
-```
-
-## Architecture
-
-The monorepo structure uses npm workspaces to manage three interdependent components:
-
-```
-f5xc/
-├── packages/
-│   ├── f5xc-auth/              # Core authentication library (TypeScript)
-│   ├── f5xc-api-mcp/           # MCP server wrapper (TypeScript)
-│   └── terraform-provider/     # Terraform provider (Go)
-├── package.json                # Workspace root configuration
-├── README.md                   # This file
-└── .github/                    # GitHub workflows
-```
-
-## Authentication Flow
-
-1. **f5xc-auth**: Handles credential management and profile storage
-2. **f5xc-api-mcp**: Uses f5xc-auth for API authentication
-3. **terraform-provider**: Can use f5xc-auth patterns for credential handling
+- **Multiple auth methods** - API tokens, P12 certificates, cert/key pairs
+- **XDG-compliant storage** - Profiles in `~/.config/f5xc/profiles/`
+- **Environment override** - Use env vars for CI/CD contexts
+- **URL normalization** - Automatic tenant URL handling
+- **Pre-configured HTTP** - Axios client with auth and retry logic
+- **TypeScript** - Full type safety and IntelliSense support
 
 ## Documentation
 
-- [f5xc-auth Documentation](./packages/f5xc-auth/docs/)
-- [f5xc-api-mcp Documentation](./packages/f5xc-api-mcp/)
-- [Terraform Provider Documentation](./packages/terraform-provider/)
+Full documentation: **https://robinmordasiewicz.github.io/f5xc-auth/**
 
-## License
+- [Authentication Guide](https://robinmordasiewicz.github.io/f5xc-auth/authentication/)
+- [API Reference](https://robinmordasiewicz.github.io/f5xc-auth/api/)
+- [Examples](https://robinmordasiewicz.github.io/f5xc-auth/examples/)
 
-MIT - See individual package LICENSE files for details.
+## Requirements
+
+Node.js >= 18
 
 ## Contributing
 
-See [Contributing Guidelines](./packages/f5xc-auth/docs/contributing.md) in the f5xc-auth package.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development guidelines and automated release process.
 
-## Support
+## License
 
-- **Issues**: [GitHub Issues](https://github.com/robinmordasiewicz/f5xc/issues)
-- **F5 Distributed Cloud Docs**: https://docs.cloud.f5.com/
-- **Terraform Registry**: https://registry.terraform.io/providers/robinmordasiewicz/f5xc/
-
-## Author
-
-Robin Mordasiewicz
+MIT - see [LICENSE](./LICENSE)


### PR DESCRIPTION
## Summary

Updates project documentation to focus on the f5xc-auth package with clear guidance for contributors.

## Changes

- **README.md**: Simplified from monorepo overview to package-specific documentation
  - Removed monorepo references
  - Added npm version badge
  - Added MIT license badge
  - Focused description on authentication library
  
- **CONTRIBUTING.md**: New file with development workflow
  - Commit message conventions (feat/fix/docs/test/chore)
  - Breaking change guidelines
  - Development workflow steps
  - Testing requirements
  - Link to comprehensive contributing guide

## Type

docs

## Closes

#47