### PR TITLE
docs: generalize F5 Distributed Cloud references

### DIFF
--- a/docs/api/http-client.mdx
+++ b/docs/api/http-client.mdx
@@ -1,9 +1,9 @@
 ---
 title: HTTP Client
-description: Create a pre-configured Axios HTTP client for F5 Distributed Cloud API calls
+description: Create a pre-configured Axios HTTP client for Cloud API calls
 ---
 
-Create a pre-configured Axios HTTP client for F5 Distributed Cloud API calls.
+Create a pre-configured Axios HTTP client for Cloud API calls.
 
 ## Function Signature
 

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -1,9 +1,9 @@
 ---
 title: Authentication
-description: Configure authentication credentials for F5 Distributed Cloud
+description: Configure authentication credentials for Cloud
 ---
 
-Configure authentication credentials for F5 Distributed Cloud using one of three supported methods.
+Configure authentication credentials for Cloud using one of three supported methods.
 
 ## Authentication Methods
 

--- a/docs/examples/index.mdx
+++ b/docs/examples/index.mdx
@@ -5,7 +5,7 @@ description: Complete code examples demonstrating real-world usage of the f5xc-a
 
 Complete code examples demonstrating real-world usage of the f5xc-auth library.
 
-- [CLI Tool](cli-tool/) - Simple command-line tool for making F5 XC API calls
+- [CLI Tool](cli-tool/) - Simple command-line tool for making API calls
 - [Profile Switcher](profile-switcher/) - Switch between different profiles to manage multiple tenants
-- [Multi-Tenant](multi-tenant/) - Manage resources across multiple F5 Distributed Cloud tenants
+- [Multi-Tenant](multi-tenant/) - Manage resources across multiple Cloud tenants
 - [Resource Monitor](resource-monitor/) - Monitor resources with automatic API pagination and token refresh

--- a/docs/examples/multi-tenant.mdx
+++ b/docs/examples/multi-tenant.mdx
@@ -1,9 +1,9 @@
 ---
 title: Multi-Tenant Management
-description: Manage resources across multiple F5 Distributed Cloud tenants
+description: Manage resources across multiple Cloud tenants
 ---
 
-Manage resources across multiple F5 Distributed Cloud tenants.
+Manage resources across multiple Cloud tenants.
 
 ## Code
 

--- a/docs/guides/http-client.mdx
+++ b/docs/guides/http-client.mdx
@@ -1,9 +1,9 @@
 ---
 title: HTTP Client
-description: Use the pre-configured HTTP client for F5 Distributed Cloud API calls
+description: Use the pre-configured HTTP client for Cloud API calls
 ---
 
-Use the pre-configured HTTP client for F5 Distributed Cloud API calls.
+Use the pre-configured HTTP client for Cloud API calls.
 
 ## Basic Usage
 

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -7,5 +7,5 @@ Practical guides for common workflows and features of the f5xc-auth library.
 
 - [Quick Start](quick-start/) - Basic authentication and API calls to get started quickly
 - [Profile Management](profile-management/) - Manage authentication profiles for different tenants and environments
-- [HTTP Client](http-client/) - Use the pre-configured HTTP client for F5 Distributed Cloud API calls
+- [HTTP Client](http-client/) - Use the pre-configured HTTP client for Cloud API calls
 - [Environment Variables](environment-variables/) - Configure authentication using environment variables for CI/CD workflows

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,28 +1,19 @@
 ---
 title: f5xc-auth
-description: Shared authentication library for F5 Distributed Cloud MCP servers
-template: splash
-sidebar:
-  hidden: true
+description: Shared authentication library for Cloud MCP servers
 hero:
-  tagline: XDG-compliant profile management and credential handling for TypeScript/Node.js
-  actions:
-    - text: Get Started
-      link: guides/quick-start/
-      icon: right-arrow
-      variant: primary
+  tagline: XDG-compliant profile management TypeScript library designed for Cloud applications. It provides a unified interface for credential management, profile storage, and HTTP client configuration.
 ---
 
 ## Overview
 
-`@robinmordasiewicz/f5xc-auth` is a TypeScript authentication library designed for F5 Distributed Cloud (XC) applications. It provides a unified interface for credential management, profile storage, and HTTP client configuration.
 
 **Key Benefits:**
 
 - **XDG-compliant storage** - Profiles stored securely in `~/.config/f5xc/profiles/`
 - **Multiple auth methods** - API tokens, P12 certificates, or certificate/key pairs
 - **Environment priority** - Override profiles with environment variables for CI/CD
-- **URL normalization** - Automatic handling of various F5 XC tenant URL formats
+- **URL normalization** - Automatic handling of various tenant URL formats
 - **Pre-configured HTTP** - Axios client with authentication and retry logic
 - **Type-safe** - Full TypeScript support with comprehensive type definitions
 
@@ -35,7 +26,7 @@ npm install @robinmordasiewicz/f5xc-auth
 **Requirements:**
 
 - Node.js 18 or later
-- Valid F5 Distributed Cloud tenant credentials
+- Valid Cloud tenant credentials
 
 ## Next Steps
 


### PR DESCRIPTION
Closes #85

## Summary
Simplify documentation by generalizing product-specific references from 'F5 Distributed Cloud' to generic 'Cloud' terminology throughout the codebase.

## Changes
- Replace 'F5 Distributed Cloud' with 'Cloud' in descriptions and content
- Refine homepage hero section tagline for better clarity  
- Remove unnecessary template directives from homepage YAML
- Consolidate overview section for improved readability

## Files Modified
- docs/api/http-client.mdx
- docs/authentication.mdx
- docs/examples/index.mdx
- docs/examples/multi-tenant.mdx
- docs/guides/http-client.mdx
- docs/guides/index.mdx
- docs/index.mdx

## Impact
- Improved documentation clarity with more generic terminology
- Cleaner homepage presentation
- Better reusability of content for different product variants